### PR TITLE
fix memcpy and memset alignment bug

### DIFF
--- a/libs/klib/src/string.c
+++ b/libs/klib/src/string.c
@@ -53,7 +53,7 @@ void* memset(void* v,int c,size_t n){
 
   if (n >= threshold) {
     // first let dst aligned by 8 bytes
-    int pad = (uintptr_t)dst % 8;
+    int pad = (8 - (uintptr_t)dst % 8) % 8;
     n -= pad;
     while (pad --) { *dst ++ = c; }
 
@@ -102,7 +102,7 @@ void* memcpy(void* out, const void* in, size_t n) {
 
   if (n >= threshold && is_align8) {
     // first let dst aligned by 8 bytes
-    int pad = (uintptr_t)dst % 8;
+    int pad = (8 - (uintptr_t)dst % 8) % 8;
     n -= pad;
     while (pad --) { *dst ++ = *src ++; }
 
@@ -131,7 +131,7 @@ void* memcpy(void* out, const void* in, size_t n) {
 
   if (n >= threshold && is_align4) {
     // first let dst aligned by 4 bytes
-    int pad = (uintptr_t)dst % 4;
+    int pad = (4 - (uintptr_t)dst % 4) % 4;
     n -= pad;
     while (pad --) { *dst ++ = *src ++; }
 


### PR DESCRIPTION
Hi, [I had a bunch of trouble with my XiangShan simulation hanging](https://github.com/OpenXiangShan/XiangShan/issues/2890), while one bug was rtl related, I tracked down another bug to the memset implementation.

It turns out that the nexus-am code doesn't properly align the pointers, and thus causes unaligned memory accesses.

`dst % 8` for `dst=9` gives you `1`, but `1+9` isn't a multiple of `8`. Instead you need to subtract the module, but make sure you stay in bounds: `(8 - dst % 8) % 8`

It's an easy oversight, I only recognized it because I made the same mistake before. 