### PR TITLE
fix coremark score int overflow when ITERATIONS > 10000. (10000 * 100…

### DIFF
--- a/apps/coremark/src/core_main.c
+++ b/apps/coremark/src/core_main.c
@@ -318,9 +318,9 @@ MAIN_RETURN_TYPE main(int argc, char *argv[]) {
   ee_printf("Finished in %d ms.\n", (int)total_time);
 	if (total_errors==0) {
     ee_printf("==================================================\n");
-	  ee_printf("CoreMark Iterations/Sec %d\n", 
-        default_num_contexts * ITERATIONS * 1000 * 1000 / time_in_secs(total_time)
-      );
+	ee_printf("CoreMark Iterations/Sec %.2f\n", 
+		(double)default_num_contexts * ITERATIONS * 1000.0 * 1000.0 / time_in_secs(total_time)
+	);
   }
 	if (total_errors>0)
 		ee_printf("Errors detected\n");


### PR DESCRIPTION
fix coremark score int overflow when ITERATIONS > 10000. (10000 * 1000 * 1000 > INT_MAX)
use double instead.