### PR TITLE
feat(multi-cores): allocate seperate stack for each hart in riscv64-xs config

### DIFF
--- a/am/src/nemu/isa/riscv/boot/start.S
+++ b/am/src/nemu/isa/riscv/boot/start.S
@@ -32,12 +32,17 @@
 _start:
   init_regs
 
-  mv s0, zero
-  la sp, _stack_pointer
   li a0, MSTATUS_FS & (MSTATUS_FS >> 1)
   csrs mstatus, a0
   csrwi fcsr, 0
 
   init_fregs # init fregs after fp enable
+
+  la t0, _stack_top
+  la t1, _stack_pointer
+  sub t3, t1, t0
+  csrr t4, mhartid
+  mul t5, t3, t4
+  add sp, t5, t1
 
   jal _trm_init

--- a/am/src/nemu/isa/riscv/boot/start_flash.S
+++ b/am/src/nemu/isa/riscv/boot/start_flash.S
@@ -10,7 +10,6 @@
 
 _start:
   mv s0, zero
-  la sp, _stack_pointer
   li a0, MSTATUS_FS & (MSTATUS_FS >> 1)
   csrs mstatus, a0
   csrwi fcsr, 0
@@ -24,5 +23,12 @@ _start:
   # li    a1, (0x8b << 16) // locked, top of range, +wr, -x
   # or    a0, a0, a1
   # csrw  pmpcfg0, a0
+
+  la t0, _stack_top
+  la t1, _stack_pointer
+  sub t3, t1, t0
+  csrr t4, mhartid
+  mul t5, t3, t4
+  add sp, t5, t1
 
   jal _trm_init

--- a/am/src/nemu/ldscript/section.ld
+++ b/am/src/nemu/ldscript/section.ld
@@ -25,6 +25,7 @@ SECTIONS {
   _stack_top = ALIGN(0x1000);
   . = _stack_top + 0x8000;
   _stack_pointer = .;
+  . = _stack_top + 0x320000;
   end = .;
   _end = .;
   _heap_start = ALIGN(0x1000);

--- a/libs/klib/include/klib.h
+++ b/libs/klib/include/klib.h
@@ -78,6 +78,10 @@ void free(void *ptr);
 
 void qsort(void *base, size_t nmemb, size_t size, int (*compar)(const void *, const void *));
 
+uint64_t compare_and_swap(volatile uint64_t*, uint64_t, uint64_t);
+void lock(volatile uint64_t *);
+void release(volatile uint64_t *);
+
 // assert.h
 #ifdef NDEBUG
   #define assert(ignore) ((void)0)

--- a/libs/klib/src/atomic.c
+++ b/libs/klib/src/atomic.c
@@ -1,0 +1,30 @@
+#include "klib.h"
+#include <klib-macros.h>
+
+uint64_t compare_and_swap(volatile uint64_t* addr, uint64_t old_val, uint64_t new_val) {
+  uint64_t check = 0;
+  uint64_t value = 0;
+  asm volatile (
+    "lr.d %[value], (%[addr]);"
+    : [value]"=r"(value)
+    : [addr]"p"(addr)
+  );
+  if (value != old_val) return 1;
+  asm volatile (
+    "sc.d %[check], %[write], (%[addr]);"
+    : [check]"=r"(check)
+    : [write]"r"(new_val), [addr]"p"(addr)
+  );
+  return check;
+}
+
+void lock(volatile uint64_t *addr) {
+  asm volatile("csrci mstatus, 0x8");
+  while(compare_and_swap(addr, 0, 1));
+}
+
+void release(volatile uint64_t *addr) {
+  *addr = 1;
+  asm volatile("fence");
+  asm volatile("csrsi mstatus, 0x8");
+}

--- a/libs/klib/src/printf.c
+++ b/libs/klib/src/printf.c
@@ -859,13 +859,18 @@ static int _vsnprintf(out_fct_type out, char* buffer, const size_t maxlen, const
 
 ///////////////////////////////////////////////////////////////////////////////
 #ifndef NOPRINT
+void lock(volatile uint64_t *);
+void release(volatile uint64_t *);
+volatile uint64_t print_lock = 0;
 int printf_(const char* format, ...)
 {
   va_list va;
+  lock(&print_lock);
   va_start(va, format);
   char buffer[1];
   const int ret = _vsnprintf(_out_char, buffer, (size_t)-1, format, va);
   va_end(va);
+  release(&print_lock);
   return ret;
 }
 #else


### PR DESCRIPTION
Altering boot codes and link scripts.
Respectively allocating 32KiB stack space for each hart. 
Adding support for baremetal test cases running on DUT with up to 64 harts.