### PR TITLE
fix(cas, test): handle rv32 cases, remove sv39-only tests on rv32

### DIFF
--- a/am/am.h
+++ b/am/am.h
@@ -87,7 +87,9 @@ void _map(_AddressSpace *as, void *va, void *pa, int prot);
 _Context *_ucontext(_AddressSpace *as, _Area kstack, void *entry);
 
 // a fault map for xiangshan testing access fault
+#if __riscv_xlen == 64
 void _map_fault(_AddressSpace *as, void *va, void *pa, int prot);
+#endif
 
 // hugepage map for xiangshan testing
 void _map_rv_hugepage(_AddressSpace *as, void *va, void *pa, int prot, int pagetable_level);

--- a/am/src/nemu/isa/riscv/vme.c
+++ b/am/src/nemu/isa/riscv/vme.c
@@ -176,6 +176,7 @@ void _map(_AddressSpace *as, void *va, void *pa, int prot) {
  * A wrong map to test access fault, high bits of ppn is not zero
  * Only available for sv39 and paddr = 36! (ppnlen can not be changed)
  */
+#if __riscv_xlen == 64
 void _map_fault(_AddressSpace *as, void *va, void *pa, int prot) {
   assert((uintptr_t)va % PGSIZE == 0);
   assert((uintptr_t)pa % PGSIZE == 0);
@@ -202,6 +203,7 @@ void _map_fault(_AddressSpace *as, void *va, void *pa, int prot) {
     *pte = PTE_V | prot | (PN(pa) << 10) | (randnum << 34);
   }
 }
+#endif
 
 /*
  * map va to pa with prot permission with page table root as

--- a/libs/klib/include/klib.h
+++ b/libs/klib/include/klib.h
@@ -78,9 +78,9 @@ void free(void *ptr);
 
 void qsort(void *base, size_t nmemb, size_t size, int (*compar)(const void *, const void *));
 
-uint64_t compare_and_swap(volatile uint64_t*, uint64_t, uint64_t);
-void lock(volatile uint64_t *);
-void release(volatile uint64_t *);
+size_t compare_and_swap(volatile size_t*, size_t, size_t);
+void lock(volatile size_t *);
+void release(volatile size_t *);
 
 // assert.h
 #ifdef NDEBUG

--- a/libs/klib/src/atomic.c
+++ b/libs/klib/src/atomic.c
@@ -1,29 +1,46 @@
 #include "klib.h"
 #include <klib-macros.h>
 
-uint64_t compare_and_swap(volatile uint64_t* addr, uint64_t old_val, uint64_t new_val) {
-  uint64_t check = 0;
-  uint64_t value = 0;
+size_t compare_and_swap(volatile size_t* addr, size_t old_val, size_t new_val) {
+  size_t check = 0;
+  size_t value = 0;
+  #if __riscv_xlen == 64
   asm volatile (
     "lr.d %[value], (%[addr]);"
     : [value]"=r"(value)
     : [addr]"p"(addr)
   );
+  #else
+  asm volatile (
+    "lr.w %[value], (%[addr]);"
+    : [value]"=r"(value)
+    : [addr]"p"(addr)
+  );
+  #endif
+
   if (value != old_val) return 1;
+  #if __riscv_xlen == 64
   asm volatile (
     "sc.d %[check], %[write], (%[addr]);"
     : [check]"=r"(check)
     : [write]"r"(new_val), [addr]"p"(addr)
   );
+  #else
+  asm volatile (
+    "sc.w %[check], %[write], (%[addr]);"
+    : [check]"=r"(check)
+    : [write]"r"(new_val), [addr]"p"(addr)
+  );
+  #endif
   return check;
 }
 
-void lock(volatile uint64_t *addr) {
+void lock(volatile size_t *addr) {
   asm volatile("csrci mstatus, 0x8");
   while(compare_and_swap(addr, 0, 1));
 }
 
-void release(volatile uint64_t *addr) {
+void release(volatile size_t *addr) {
   *addr = 0;
   asm volatile("fence");
   asm volatile("csrsi mstatus, 0x8");

--- a/libs/klib/src/stdlib.c
+++ b/libs/klib/src/stdlib.c
@@ -33,7 +33,7 @@ static struct {
   uintptr_t size;
 } last = { .ptr = NULL, .size = 0 };
 
-volatile uint64_t malloc_lock = 0;
+volatile size_t malloc_lock = 0;
 
 void *malloc(size_t size) {
   lock(&malloc_lock);


### PR DESCRIPTION
This PR addresses several compilation issues encountered when building for the RV32 architecture.

## Issues
### Compilation Errors in `_map_fault`
The current implementation of `_map_fault` results in compilation errors, as it is specifically designed for RV64. The following error occurs:
```
am/src/nemu/isa/riscv/vme.c:202:53: error: left shift count >= width of type [-Werror=shift-count-overflow]
02 |     *pte = PTE_V | prot | (PN(pa) << 10) | (randnum << 34);
```
### Non-portable Data Types
The use of `uint64_t` in the `compare_and_swap`, `lock`, and `release` functions is not portable, leading to compilation errors on RV32.
### Inline Assembly for `lr` and `sc`
The inline assembly for `lr` (load reserved) and `sc` (store conditional) should be handled separately for RV32 and RV64 to ensure compatibility.
## Proposed Changes
- Modify the `_map_fault` function to ensure compatibility with RV32.
- Replace `uint64_t` with a more portable data type in the affected functions.
- Separate the inline assembly for `lr` and `sc` to accommodate the different architectures.