### PR TITLE
add benchmark tsvc

### DIFF
--- a/apps/tsvc/Makefile
+++ b/apps/tsvc/Makefile
@@ -1,0 +1,5 @@
+NAME = tsvc
+SRCS = $(shell find -L ./src/ -name "*.c")
+CFLAGS := -O3 -fstrict-aliasing -fivopts -ftree-vectorize
+MARCH ?= rv64gcv_zba_zbb_zbc_zbs_zbkb_zbkc_zbkx_zknd_zkne_zknh_zkr_zksed_zksh_zkt
+include $(AM_HOME)/Makefile.app

--- a/apps/tsvc/README.md
+++ b/apps/tsvc/README.md
@@ -1,0 +1,25 @@
+# TSVC 2
+
+Updated version of TSVC to capture the same information but hopefully in a better format to make it easier to add things. We've fixed a few bugs along the way too.
+
+The original paper which laid out the details of the suite and provided results (D. Callahan, J. Dongarra, and D. Levine. Vectorizing compilers: a test suite and results. Proceedings. Supercomputing ’88) originally had the loops in Fortran.
+
+The C version of the benchmark used as a base for TSVC-2 was found [here](http://polaris.cs.uiuc.edu/~maleki1/TSVC.tar.gz). The old C version had some problems to do with compilers being able to inline all of the initialisation and checksum loops, which wildly skews the results and the timing. There are also some bugs with writing off the end of arrays and some of the initialisation routines seem to not initialise the right arrays. 
+
+This version should (hopefully) be free(er) of bugs and should stop the compiler from being able to completely eliminate code.
+
+## Original Repository
+
+https://github.com/UoB-HPC/TSVC_2
+
+## Changes
+
+To perform the test, we made the following modifications to the original program:
+
+1. We modified the makefile to enable compilation in the AM environment.
+
+2. We reduced the value of the iterations variable in common.h (from 100,000 to 100) to shorten the runtime.
+
+3. We added the library files required for the test (undefined_lib.h, undefined_lib.c), specifically the sinf and cosf functions needed for test s451. This may lead to performance and result differences compared to running on a Linux system.
+
+The tests show that the benchmark can run successfully on the riscv64-xs architecture in NEMU.

--- a/apps/tsvc/include/array_defs.h
+++ b/apps/tsvc/include/array_defs.h
@@ -1,0 +1,20 @@
+#ifndef TSVC_ARRAY_HDR
+#define TSVC_ARRAY_HDR
+
+// Arrays used by TSVC and common.c
+
+#define ARRAY_ALIGNMENT 64
+
+extern __attribute__((aligned(ARRAY_ALIGNMENT))) real_t flat_2d_array[LEN_2D*LEN_2D];
+
+extern __attribute__((aligned(ARRAY_ALIGNMENT))) real_t x[LEN_1D];
+
+extern __attribute__((aligned(ARRAY_ALIGNMENT))) real_t a[LEN_1D],b[LEN_1D],c[LEN_1D],d[LEN_1D],e[LEN_1D],
+                                   aa[LEN_2D][LEN_2D],bb[LEN_2D][LEN_2D],cc[LEN_2D][LEN_2D],tt[LEN_2D][LEN_2D];
+
+extern __attribute__((aligned(ARRAY_ALIGNMENT))) int indx[LEN_1D];
+
+extern real_t* __restrict__ xx;
+extern real_t* yy;
+
+#endif

--- a/apps/tsvc/include/common.h
+++ b/apps/tsvc/include/common.h
@@ -1,0 +1,35 @@
+#ifndef TSVC_COMMON_HDR
+#define TSVC_COMMON_HDR
+
+// #define iterations 100000
+#define iterations 100
+#define LEN_1D 32000
+#define LEN_2D 256
+
+// #include <sys/time.h>
+#include "undefined_lib.h"
+#include <klib.h>
+#include <stdint.h>
+
+struct args_t {
+    struct timeval t1;
+    struct timeval t2;
+    void * __restrict__ arg_info;
+};
+
+#if 0
+typedef double real_t;
+#define ABS fabs
+#else
+typedef float real_t;
+#define ABS fabsf
+#endif
+
+int dummy(real_t[LEN_1D], real_t[LEN_1D], real_t[LEN_1D], real_t[LEN_1D], real_t[LEN_1D], real_t[LEN_2D][LEN_2D], real_t[LEN_2D][LEN_2D], real_t[LEN_2D][LEN_2D], real_t);
+
+void init(int** ip, real_t* s1, real_t* s2);
+
+int initialise_arrays(const char* name);
+real_t calc_checksum(const char * name);
+
+#endif

--- a/apps/tsvc/include/undefined_lib.h
+++ b/apps/tsvc/include/undefined_lib.h
@@ -17,7 +17,6 @@ void *memalign(size_t alignment, size_t size);
 int gettimeofday(struct timeval *rtc, void * null);
 int fprintf(void *file, const char *format, ...);
 float fabsf(float x);
-int exit(int x);
 float sinf(float x);
 float cosf(float x);
 #endif

--- a/apps/tsvc/include/undefined_lib.h
+++ b/apps/tsvc/include/undefined_lib.h
@@ -1,0 +1,23 @@
+#ifndef __UNDEFINED_LIBC__
+// #include <stdio.h>
+// #include <stdlib.h>
+// #include <sys/mman.h>
+// #include <unistd.h>
+// #include <stdint.h>
+#include "klib.h"
+#include "printf.h"
+#define PI 3.14159265358979323846
+
+struct timeval {
+    long tv_sec;
+    long tv_usec;
+};
+
+void *memalign(size_t alignment, size_t size);
+int gettimeofday(struct timeval *rtc, void * null);
+int fprintf(void *file, const char *format, ...);
+float fabsf(float x);
+int exit(int x);
+float sinf(float x);
+float cosf(float x);
+#endif

--- a/apps/tsvc/license.txt
+++ b/apps/tsvc/license.txt
@@ -1,0 +1,58 @@
+Copyright (c) 2011 University of Illinois at Urbana-Champaign.  All rights reserved.
+
+
+
+Developed by: Polaris Research Group
+
+              University of Illinois at Urbana-Champaign
+
+              http://polaris.cs.uiuc.edu
+
+
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+
+of this software and associated documentation files (the "Software"), to
+
+deal with the Software without restriction, including without limitation the
+
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+
+sell copies of the Software, and to permit persons to whom the Software is
+
+furnished to do so, subject to the following conditions:
+
+  1. Redistributions of source code must retain the above copyright notice,
+
+     this list of conditions and the following disclaimers.
+
+  2. Redistributions in binary form must reproduce the above copyright
+
+     notice, this list of conditions and the following disclaimers in the
+
+     documentation and/or other materials provided with the distribution.
+
+  3. Neither the names of Polaris Research Group, University of Illinois at
+
+     Urbana-Champaign, nor the names of its contributors may be used to endorse
+
+     or promote products derived from this Software without specific prior
+
+     written permission.
+
+
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+
+CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+
+WITH THE SOFTWARE.
+

--- a/apps/tsvc/src/common.c
+++ b/apps/tsvc/src/common.c
@@ -1,0 +1,1037 @@
+
+#include "common.h"
+#include "array_defs.h"
+// #include <stdio.h>
+// #include <stdlib.h>
+// #include <malloc.h>
+// #include <string.h>
+
+void set_1d_array(real_t * arr, int length, real_t value, int stride);
+void set_2d_array(real_t arr[LEN_2D][LEN_2D], real_t value, int stride);
+
+enum {SET1D_RECIP_IDX = -1, SET1D_RECIP_IDX_SQ = -2};
+
+real_t sum1d(real_t arr[LEN_1D]);
+real_t sum2d(real_t arr[LEN_2D][LEN_2D]);
+
+real_t sum_x();
+real_t sum_a();
+real_t sum_b();
+real_t sum_c();
+real_t sum_e();
+
+real_t sum_half_xx();
+
+real_t sum_a_aa();
+
+real_t sum_aa();
+real_t sum_bb();
+real_t sum_cc();
+real_t sum_xx();
+
+real_t sum_aa_bb();
+
+real_t sum_flat_2d_array();
+
+real_t sum1d(real_t arr[LEN_1D]){
+    real_t ret = 0.;
+    for (int i = 0; i < LEN_1D; i++)
+        ret += arr[i];
+    return ret;
+}
+
+real_t sum2d(real_t arr[LEN_2D][LEN_2D]){
+    real_t sum = 0.;
+    for (int i = 0; i < LEN_2D; i++){
+        for (int j = 0; j < LEN_2D; j++){
+            sum += arr[i][j];
+        }
+    }
+
+    return sum;
+}
+
+real_t sum_x()
+{
+    return sum1d(x);
+}
+
+real_t sum_xx()
+{
+    return sum1d(xx);
+}
+
+real_t sum_a()
+{
+    return sum1d(a);
+}
+
+real_t sum_b()
+{
+    return sum1d(b);
+}
+
+real_t sum_a_aa()
+{
+    return sum1d(a) + sum2d(aa);
+}
+
+real_t sum_c()
+{
+    return sum1d(c);
+}
+
+real_t sum_e()
+{
+    return sum1d(e);
+}
+
+real_t sum_aa()
+{
+    return sum2d(aa);
+}
+
+real_t sum_bb()
+{
+    return sum2d(bb);
+}
+
+real_t sum_aa_bb()
+{
+    return sum2d(aa) + sum2d(bb);
+}
+
+real_t sum_cc()
+{
+    return sum2d(cc);
+}
+
+real_t sum_half_xx()
+{
+    real_t temp = 00;
+
+    for (int i = 0; i < LEN_1D/2; i++){
+        temp += xx[i];
+    }
+
+    return temp;
+}
+
+real_t sum_flat_2d_array()
+{
+    real_t sum = 0.;
+
+    for (int i = 0; i < LEN_2D*LEN_2D; i++){
+        sum += flat_2d_array[i];
+    }
+
+    return sum;
+}
+
+
+void set_1d_array(real_t * arr, int length, real_t value, int stride)
+{
+    if (stride == SET1D_RECIP_IDX) {
+        for (int i = 0; i < length; i++) {
+            arr[i] = 1. / (real_t) (i+1);
+        }
+    } else if (stride == SET1D_RECIP_IDX_SQ) {
+        for (int i = 0; i < length; i++) {
+            arr[i] = 1. / (real_t) ((i+1) * (i+1));
+        }
+    } else {
+        for (int i = 0; i < length; i += stride) {
+            arr[i] = value;
+        }
+    }
+}
+
+void set_2d_array(real_t arr[LEN_2D][LEN_2D], real_t value, int stride)
+{
+    for (int i = 0; i < LEN_2D; i++) {
+        set_1d_array(arr[i], LEN_2D, value, stride);
+    }
+}
+
+void init(int** ip, real_t* s1, real_t* s2){
+    xx = (real_t*) memalign(ARRAY_ALIGNMENT, LEN_1D*sizeof(real_t));
+    *ip = (int *) memalign(ARRAY_ALIGNMENT, LEN_1D*sizeof(real_t));
+
+    for (int i = 0; i < LEN_1D; i = i+5){
+        (*ip)[i]   = (i+4);
+        (*ip)[i+1] = (i+2);
+        (*ip)[i+2] = (i);
+        (*ip)[i+3] = (i+3);
+        (*ip)[i+4] = (i+1);
+    }
+
+    set_1d_array(a, LEN_1D, 1.,1);
+    set_1d_array(b, LEN_1D, 1.,1);
+    set_1d_array(c, LEN_1D, 1.,1);
+    set_1d_array(d, LEN_1D, 1.,1);
+    set_1d_array(e, LEN_1D, 1.,1);
+    set_1d_array(x, LEN_1D, 1.,1);
+    set_2d_array(aa, 0.,SET1D_RECIP_IDX);
+    set_2d_array(bb, 0.,SET1D_RECIP_IDX);
+    set_2d_array(cc, 0.,SET1D_RECIP_IDX);
+
+    for (int i = 0; i < LEN_1D; i++) {
+        indx[i] = (i+1) % 4+1;
+    }
+
+    *s1 = 1.0;
+    *s2 = 2.0;
+}
+
+int initialise_arrays(const char* name)
+{
+    real_t any=0.;
+    real_t zero=0.;
+    real_t half=.5;
+    real_t one=1.;
+    real_t two=2.;
+    real_t small = .000001;
+    int unit =1;
+    int frac = SET1D_RECIP_IDX;
+    int frac2 = SET1D_RECIP_IDX_SQ;
+
+    printf("%5s\t", name);
+
+    if    (!strcmp(name, "s000")) {
+      for (int i = 0; i < LEN_1D; i++) {
+            a[i] = 1+i;
+            b[i] = 2+i;
+            c[i] = 3+i;
+            d[i] = 4+i;
+            e[i] = 5+i;
+          }
+    } else if (!strcmp(name, "s111")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, any,frac2);
+        set_1d_array(c, LEN_1D, any,frac2);
+        set_1d_array(d, LEN_1D, any,frac2);
+        set_1d_array(e, LEN_1D, any,frac2);
+    } else if (!strcmp(name, "s112")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, any,frac2);
+    } else if (!strcmp(name, "s113")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, any,frac2);
+    } else if (!strcmp(name, "s114")) {
+        set_2d_array(aa, any,frac);
+        set_2d_array(bb, any,frac2);
+    } else if (!strcmp(name, "s115")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_2d_array(aa,small,unit);
+        set_2d_array(bb,small,unit);
+        set_2d_array(cc,small,unit);
+    } else if (!strcmp(name, "s116")) {
+        set_1d_array(a, LEN_1D, one,unit);
+    } else if (!strcmp(name, "s118")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_2d_array(bb,small,unit);
+    } else if (!strcmp(name, "s119")) {
+        set_2d_array(aa, one,unit);
+        set_2d_array(bb, any,frac2);
+    } else if (!strcmp(name, "s121")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, any,frac2);
+    } else if (!strcmp(name, "s122")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, any,frac2);
+    } else if (!strcmp(name, "s123")) {
+        set_1d_array(a, LEN_1D,zero,unit);
+        set_1d_array(b, LEN_1D, one,unit);
+        set_1d_array(c, LEN_1D, one,unit);
+        set_1d_array(d, LEN_1D, any,frac);
+        set_1d_array(e, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s124")) {
+        set_1d_array(a, LEN_1D,zero,unit);
+        set_1d_array(b, LEN_1D, one,unit);
+        set_1d_array(c, LEN_1D, one,unit);
+        set_1d_array(d, LEN_1D, any,frac);
+        set_1d_array(e, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s125")) {
+        set_1d_array(flat_2d_array, LEN_2D*LEN_2D,zero,unit);
+        set_2d_array(aa, one,unit);
+        set_2d_array(bb,half,unit);
+        set_2d_array(cc, two,unit);
+    } else if (!strcmp(name, "s126")) {
+        set_2d_array(bb, one,unit);
+        set_1d_array( flat_2d_array, LEN_2D*LEN_2D,any,frac);
+        set_2d_array(cc, any,frac);
+    } else if (!strcmp(name, "s127")) {
+        set_1d_array(a, LEN_1D,zero,unit);
+        set_1d_array(b, LEN_1D, one,unit);
+        set_1d_array(c, LEN_1D, any,frac);
+        set_1d_array(d, LEN_1D, any,frac);
+        set_1d_array(e, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s128")) {
+        set_1d_array(a, LEN_1D,zero,unit);
+        set_1d_array(b, LEN_1D, two,unit);
+        set_1d_array(c, LEN_1D, one,unit);
+        set_1d_array(d, LEN_1D, one,unit);
+    } else if (!strcmp(name, "s131")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, any,frac2);
+    } else if (!strcmp(name, "s132")) {
+        set_2d_array(aa, one,unit);
+        set_1d_array(b, LEN_1D, any,frac);
+        set_1d_array(c, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s141")) {
+        set_1d_array( flat_2d_array, LEN_2D*LEN_2D, one,unit);
+        set_2d_array(bb, any,frac2);
+    } else if (!strcmp(name, "s151")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, any,frac2);
+    } else if (!strcmp(name, "s152")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D,zero,unit);
+        set_1d_array(c, LEN_1D, any,frac);
+        set_1d_array(d, LEN_1D, any,frac);
+        set_1d_array(e, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s161")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array( &b[0], LEN_1D/2, one,2);
+        set_1d_array( &b[1], LEN_1D/2,-one,2);
+        set_1d_array(c, LEN_1D, one,unit);
+        set_1d_array(d, LEN_1D, any,frac);
+        set_1d_array(e, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s162")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, any,frac);
+        set_1d_array(c, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s171")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, any,frac2);
+    } else if (!strcmp(name, "s172")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, any,frac2);
+    } else if (!strcmp(name, "s173")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, any,frac2);
+    } else if (!strcmp(name, "s174")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, any,frac2);
+    } else if (!strcmp(name, "s175")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, any,frac2);
+    } else if (!strcmp(name, "s176")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, any,frac);
+        set_1d_array(c, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s211")) {
+        set_1d_array(a, LEN_1D,zero,unit);
+        set_1d_array(b, LEN_1D, one,unit);
+        set_1d_array(c, LEN_1D, any,frac);
+        set_1d_array(d, LEN_1D, any,frac);
+        set_1d_array(e, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s212")) {
+        set_1d_array(a, LEN_1D, any,frac);
+        set_1d_array(b, LEN_1D, one,unit);
+        set_1d_array(c, LEN_1D, one,unit);
+        set_1d_array(d, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s221")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, any,frac);
+        set_1d_array(c, LEN_1D, any,frac);
+        set_1d_array(d, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s222")) {
+        set_1d_array(a, LEN_1D,zero,unit);
+        set_1d_array(b, LEN_1D, one,unit);
+        set_1d_array(c, LEN_1D, one,unit);
+    } else if (!strcmp(name, "s231")) {
+        set_2d_array(aa, one,unit);
+        set_2d_array(bb, any,frac2);
+    } else if (!strcmp(name, "s232")) {
+        set_2d_array(aa, one,unit);
+        set_2d_array(bb,zero,unit);
+    } else if (!strcmp(name, "s233")) {
+        set_2d_array(aa, any,frac);
+        set_2d_array(bb, any,frac);
+        set_2d_array(cc, any,frac);
+    } else if (!strcmp(name, "s234")) {
+        set_2d_array(aa, one,unit);
+        set_2d_array(bb, any,frac);
+        set_2d_array(cc, any,frac);
+    } else if (!strcmp(name, "s235")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, any,frac);
+        set_1d_array(c, LEN_1D, any,frac);
+        set_2d_array(aa, one,unit);
+        set_2d_array(bb, any, frac2);
+    } else if (!strcmp(name, "s241")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, one,unit);
+        set_1d_array(c, LEN_1D, one,unit);
+        set_1d_array(d, LEN_1D, one,unit);
+    } else if (!strcmp(name, "s242")) {
+        set_1d_array(a, LEN_1D,small,unit);
+        set_1d_array(b, LEN_1D,small,unit);
+        set_1d_array(c, LEN_1D,small,unit);
+        set_1d_array(d, LEN_1D,small,unit);
+    } else if (!strcmp(name, "s243")) {
+        set_1d_array(a, LEN_1D,zero,unit);
+        set_1d_array(b, LEN_1D, one,unit);
+        set_1d_array(c, LEN_1D, any,frac);
+        set_1d_array(d, LEN_1D, any,frac);
+        set_1d_array(e, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s244")) {
+        set_1d_array(a, LEN_1D,zero,unit);
+        set_1d_array(b, LEN_1D, one,unit);
+        set_1d_array(c, LEN_1D,small,unit);
+        set_1d_array(d, LEN_1D,small,unit);
+    } else if (!strcmp(name, "s251")) {
+        set_1d_array(a, LEN_1D,zero,unit);
+        set_1d_array(b, LEN_1D, one,unit);
+        set_1d_array(c, LEN_1D, any,frac);
+        set_1d_array(d, LEN_1D, any,frac);
+        set_1d_array(e, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s252")) {
+        set_1d_array(a, LEN_1D,zero,unit);
+        set_1d_array(b, LEN_1D, one,unit);
+        set_1d_array(c, LEN_1D, one,unit);
+    } else if (!strcmp(name, "s253")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D,small,unit);
+        set_1d_array(c, LEN_1D, one,unit);
+        set_1d_array(d, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s254")) {
+        set_1d_array(a, LEN_1D,zero,unit);
+        set_1d_array(b, LEN_1D, one,unit);
+    } else if (!strcmp(name, "s255")) {
+        set_1d_array(a, LEN_1D,zero,unit);
+        set_1d_array(b, LEN_1D, one,unit);
+    } else if (!strcmp(name, "s256")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_2d_array(aa, two,unit);
+        set_2d_array(bb, one,unit);
+    } else if (!strcmp(name, "s257")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_2d_array(aa, two,unit);
+        set_2d_array(bb, one,unit);
+    } else if (!strcmp(name, "s258")) {
+        set_1d_array(a, LEN_1D, any,frac);
+        set_1d_array(b, LEN_1D,zero,unit);
+        set_1d_array(c, LEN_1D, any,frac);
+        set_1d_array(d, LEN_1D, any,frac);
+        set_1d_array(e, LEN_1D,zero,unit);
+        set_2d_array(aa, any,frac);
+    } else if (!strcmp(name, "s261")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, any,frac2);
+        set_1d_array(c, LEN_1D, any,frac2);
+        set_1d_array(d, LEN_1D, one,unit);
+    } else if (!strcmp(name, "s271")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, any,frac);
+        set_1d_array(c, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s272")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, one,unit);
+        set_1d_array(c, LEN_1D, any,frac);
+        set_1d_array(d, LEN_1D, any,frac);
+        set_1d_array(e, LEN_1D, two,unit);
+    } else if (!strcmp(name, "s273")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, one,unit);
+        set_1d_array(c, LEN_1D, one,unit);
+        set_1d_array(d, LEN_1D,small,unit);
+        set_1d_array(e, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s274")) {
+        set_1d_array(a, LEN_1D,zero,unit);
+        set_1d_array(b, LEN_1D, one,unit);
+        set_1d_array(c, LEN_1D, one,unit);
+        set_1d_array(d, LEN_1D, any,frac);
+        set_1d_array(e, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s275")) {
+        set_2d_array(aa, one,unit);
+        set_2d_array(bb,small,unit);
+        set_2d_array(cc,small,unit);
+    } else if (!strcmp(name, "s276")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, any,frac);
+        set_1d_array(c, LEN_1D, any,frac);
+        set_1d_array(d, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s277")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array( b, LEN_1D/2, one,unit);
+        set_1d_array( &b[LEN_1D/2], LEN_1D/2,-one,unit);
+        set_1d_array(c, LEN_1D, any,frac);
+        set_1d_array(d, LEN_1D, any,frac);
+        set_1d_array(e, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s278")) {
+        set_1d_array( a, LEN_1D/2,-one,unit);
+        set_1d_array( &a[LEN_1D/2], LEN_1D/2,one,unit);
+        set_1d_array(b, LEN_1D, one,unit);
+        set_1d_array(c, LEN_1D, any,frac);
+        set_1d_array(d, LEN_1D, any,frac);
+        set_1d_array(e, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s279")) {
+        set_1d_array( a, LEN_1D/2,-one,unit);
+        set_1d_array( &a[LEN_1D/2], LEN_1D/2,one,unit);
+//        set_1d_array(a, LEN_1D, -one,unit);
+        set_1d_array(b, LEN_1D, one,unit);
+        set_1d_array(c, LEN_1D, any,frac);
+        set_1d_array(d, LEN_1D, any,frac);
+        set_1d_array(e, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s2710")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, one,unit);
+        set_1d_array(c, LEN_1D, any,frac);
+        set_1d_array(d, LEN_1D, any,frac);
+        set_1d_array(e, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s2711")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, any,frac);
+        set_1d_array(c, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s2712")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, any,frac);
+        set_1d_array(c, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s281")) {
+        set_1d_array(a, LEN_1D,zero,unit);
+        set_1d_array(b, LEN_1D, one,unit);
+        set_1d_array(c, LEN_1D, one,unit);
+    } else if (!strcmp(name, "1s281")) {
+        set_1d_array(a, LEN_1D,zero,unit);
+        set_1d_array(b, LEN_1D, one,unit);
+        set_1d_array(c, LEN_1D, one,unit);
+        set_1d_array(d, LEN_1D, one,unit);
+        set_1d_array(e, LEN_1D, one,unit);
+        set_1d_array(x, LEN_1D, one,unit);
+    } else if (!strcmp(name, "s291")) {
+        set_1d_array(a, LEN_1D,zero,unit);
+        set_1d_array(b, LEN_1D, one,unit);
+    } else if (!strcmp(name, "s292")) {
+        set_1d_array(a, LEN_1D,zero,unit);
+        set_1d_array(b, LEN_1D, one,unit);
+    } else if (!strcmp(name, "s293")) {
+        set_1d_array(a, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s2101")) {
+        set_2d_array(aa, one,unit);
+        set_2d_array(bb, any,frac);
+        set_2d_array(cc, any,frac);
+    } else if (!strcmp(name, "s2102")) {
+        set_2d_array(aa,zero,unit);
+    } else if (!strcmp(name, "s2111")) {
+        set_2d_array(aa, small,unit);
+    } else if (!strcmp(name, "s311")) {
+        set_1d_array(a, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s312")) {
+        set_1d_array(a, LEN_1D,1.000001,unit);
+    } else if (!strcmp(name, "s313")) {
+        set_1d_array(a, LEN_1D, any,frac);
+        set_1d_array(b, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s314")) {
+        set_1d_array(a, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s315")) {
+        set_1d_array(a, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s316")) {
+        set_1d_array(a, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s317")) {
+    } else if (!strcmp(name, "s318")) {
+        set_1d_array(a, LEN_1D, any,frac);
+        a[LEN_1D-1] = -two;
+    } else if (!strcmp(name, "s319")) {
+        set_1d_array(a, LEN_1D,zero,unit);
+        set_1d_array(b, LEN_1D,zero,unit);
+        set_1d_array(c, LEN_1D, any,frac);
+        set_1d_array(d, LEN_1D, any,frac);
+        set_1d_array(e, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s3110")) {
+        set_2d_array(aa, any,frac);
+        aa[LEN_2D-1][LEN_2D-1] = two;
+    } else if (!strcmp(name, "s3111")) {
+        set_1d_array(a, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s3112")) {
+        set_1d_array(a, LEN_1D, any,frac2);
+        set_1d_array(b, LEN_1D,zero,unit);
+    } else if (!strcmp(name, "s3113")) {
+        set_1d_array(a, LEN_1D, any,frac);
+        a[LEN_1D-1] = -two;
+    } else if (!strcmp(name, "s321")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D,zero,unit);
+    } else if (!strcmp(name, "s322")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D,zero,unit);
+        set_1d_array(c, LEN_1D,zero,unit);
+    } else if (!strcmp(name, "s323")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, one,unit);
+        set_1d_array(c, LEN_1D, any,frac);
+        set_1d_array(d, LEN_1D, any,frac);
+        set_1d_array(e, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s331")) {
+        set_1d_array(a, LEN_1D, any,frac);
+        a[LEN_1D-1] = -one;
+    } else if (!strcmp(name, "s332")) {
+        set_1d_array(a, LEN_1D, any,frac2);
+        a[LEN_1D-1] = two;
+    } else if (!strcmp(name, "s341")) {
+        set_1d_array(a, LEN_1D,zero,unit);
+        set_1d_array(b, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s342")) {
+        set_1d_array(a, LEN_1D, any,frac);
+        set_1d_array(b, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s343")) {
+        set_2d_array(aa, any,frac);
+        set_2d_array(bb, one,unit);
+    } else if (!strcmp(name, "s351")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, one,unit);
+        c[0] = 1.;
+    } else if (!strcmp(name, "s352")) {
+        set_1d_array(a, LEN_1D, any,frac);
+        set_1d_array(b, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s353")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, one,unit);
+        c[0] = 1.;
+    } else if (!strcmp(name, "s411")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, any,frac);
+        set_1d_array(c, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s412")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, any,frac);
+        set_1d_array(c, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s413")) {
+        set_1d_array(a, LEN_1D,zero,unit);
+        set_1d_array(b, LEN_1D, one,unit);
+        set_1d_array(c, LEN_1D, one,unit);
+        set_1d_array(d, LEN_1D, any,frac);
+        set_1d_array(e, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s414")) {
+        set_2d_array(aa, one,unit);
+        set_2d_array(bb, any,frac);
+        set_2d_array(cc, any,frac);
+    } else if (!strcmp(name, "s415")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, any,frac);
+        set_1d_array(c, LEN_1D, any,frac);
+        a[LEN_1D-1] = -one;
+    } else if (!strcmp(name, "s421")) {
+        set_1d_array(a, LEN_1D, any,frac2);
+        set_1d_array(flat_2d_array, LEN_1D, one, unit);
+    } else if (!strcmp(name, "s422")) {
+        set_1d_array(flat_2d_array, LEN_1D,one,unit);
+        set_1d_array(a, LEN_1D, any,frac2);
+        set_1d_array(flat_2d_array, LEN_1D, zero, unit);
+    } else if (!strcmp(name, "s1421")) {
+        set_1d_array(b, LEN_1D, one, unit);
+    } else if (!strcmp(name, "s423")) {
+        set_1d_array(flat_2d_array, LEN_1D,zero,unit);
+        set_1d_array(a, LEN_1D, any,frac2);
+        set_1d_array(flat_2d_array, LEN_1D, one, unit);
+    } else if (!strcmp(name, "s424")) {
+        set_1d_array(flat_2d_array, LEN_1D,one,unit);
+        set_1d_array(a, LEN_1D, any,frac2);
+        set_1d_array(flat_2d_array, LEN_1D, zero, unit);
+    } else if (!strcmp(name, "s431")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, any,frac2);
+    } else if (!strcmp(name, "s432")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, any,frac2);
+    } else if (!strcmp(name, "s441")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, any,frac);
+        set_1d_array(c, LEN_1D, any,frac);
+        set_1d_array(&d[0],             LEN_1D/3  , -one,unit);
+        set_1d_array(&d[LEN_1D/3],      LEN_1D/3  , zero,unit);
+        set_1d_array(&d[(2*LEN_1D/3)],  LEN_1D/3+1, one,unit);
+    } else if (!strcmp(name, "s442")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, any,frac);
+        set_1d_array(c, LEN_1D, any,frac);
+        set_1d_array(d, LEN_1D, any,frac);
+        set_1d_array(e, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s443")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, any,frac);
+        set_1d_array(c, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s451")) {
+        set_1d_array(b, LEN_1D, any,frac);
+        set_1d_array(c, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s452")) {
+        set_1d_array(a, LEN_1D,zero,unit);
+        set_1d_array(b, LEN_1D, one,unit);
+        set_1d_array(c, LEN_1D,small,unit);
+    } else if (!strcmp(name, "s453")) {
+        set_1d_array(a, LEN_1D,zero,unit);
+        set_1d_array(b, LEN_1D, any,frac2);
+    } else if (!strcmp(name, "s471")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, one,unit);
+        set_1d_array(c, LEN_1D, one,unit);
+        set_1d_array(d, LEN_1D, any,frac);
+        set_1d_array(e, LEN_1D, any,frac);
+        set_1d_array(x, LEN_1D, zero, unit);
+    } else if (!strcmp(name, "s481")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, any,frac);
+        set_1d_array(c, LEN_1D, any,frac);
+        set_1d_array(d, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s482")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, any,frac);
+        set_1d_array(c, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s491")) {
+        set_1d_array(a, LEN_1D,zero,unit);
+        set_1d_array(b, LEN_1D, one,unit);
+        set_1d_array(c, LEN_1D, any,frac);
+        set_1d_array(d, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s4112")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s4113")) {
+        set_1d_array(a, LEN_1D,zero,unit);
+        set_1d_array(b, LEN_1D, one,unit);
+        set_1d_array(c, LEN_1D, any,frac2);
+    } else if (!strcmp(name, "s4114")) {
+        set_1d_array(a, LEN_1D,zero,unit);
+        set_1d_array(b, LEN_1D, one,unit);
+        set_1d_array(c, LEN_1D, any,frac);
+        set_1d_array(d, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s4115")) {
+        set_1d_array(a, LEN_1D, any,frac);
+        set_1d_array(b, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s4116")) {
+        set_1d_array(a, LEN_1D, any,frac);
+        set_2d_array(aa, any,frac);
+    } else if (!strcmp(name, "s4117")) {
+        set_1d_array(a, LEN_1D,zero,unit);
+        set_1d_array(b, LEN_1D, one,unit);
+        set_1d_array(c, LEN_1D, any,frac);
+        set_1d_array(d, LEN_1D, any,frac);
+    } else if (!strcmp(name, "s4121")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, any,frac);
+        set_1d_array(c, LEN_1D, any,frac);
+    } else if (!strcmp(name, "va")) {
+        set_1d_array(a, LEN_1D,zero,unit);
+        set_1d_array(b, LEN_1D, any,frac2);
+    } else if (!strcmp(name, "vag")) {
+        set_1d_array(a, LEN_1D,zero,unit);
+        set_1d_array(b, LEN_1D, any,frac2);
+    } else if (!strcmp(name, "vas")) {
+        set_1d_array(a, LEN_1D,zero,unit);
+        set_1d_array(b, LEN_1D, any,frac2);
+    } else if (!strcmp(name, "vif")) {
+        set_1d_array(a, LEN_1D,zero,unit);
+        set_1d_array(b, LEN_1D, any,frac2);
+    } else if (!strcmp(name, "vpv")) {
+        set_1d_array(a, LEN_1D,zero,unit);
+        set_1d_array(b, LEN_1D, any,frac2);
+    } else if (!strcmp(name, "vtv")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, one,unit);
+    } else if (!strcmp(name, "vpvtv")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, any,frac);
+        set_1d_array(c, LEN_1D, any,frac);
+    } else if (!strcmp(name, "vpvts")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, any,frac2);
+    } else if (!strcmp(name, "vpvpv")) {
+        set_1d_array(a, LEN_1D, any,frac2);
+        set_1d_array(b, LEN_1D, one,unit);
+        set_1d_array(c, LEN_1D,-one,unit);
+    } else if (!strcmp(name, "vtvtv")) {
+        set_1d_array(a, LEN_1D, one,unit);
+        set_1d_array(b, LEN_1D, two,unit);
+        set_1d_array(c, LEN_1D,half,unit);
+    } else if (!strcmp(name, "vsumr")) {
+        set_1d_array(a, LEN_1D, any,frac);
+    } else if (!strcmp(name, "vdotr")) {
+        set_1d_array(a, LEN_1D, any,frac);
+        set_1d_array(b, LEN_1D, any,frac);
+    } else if (!strcmp(name, "vbor")) {
+        set_1d_array(a, LEN_1D, any,frac);
+        set_1d_array(b, LEN_1D, any,frac);
+        set_1d_array(c, LEN_1D, one,frac);
+        set_1d_array(d, LEN_1D, two,frac);
+        set_1d_array(e, LEN_1D,half,frac);
+        set_2d_array(aa, any,frac);
+    } else {
+    }
+
+    return 0;
+}
+
+real_t calc_checksum(const char * name)
+{
+    if (!strcmp(name, "s000")) {
+        return sum_a();
+    } else if (!strcmp(name, "s111")) {
+        return sum_a();
+    } else if (!strcmp(name, "s1111")) {
+        return sum_a();
+    } else if (!strcmp(name, "s112")) {
+        return sum_a();
+    } else if (!strcmp(name, "s1112")) {
+        return sum_a();
+    } else if (!strcmp(name, "s113")) {
+        return sum_a();
+    } else if (!strcmp(name, "s1113")) {
+        return sum_a();
+    } else if (!strcmp(name, "s114")) {
+        return sum_aa();
+    } else if (!strcmp(name, "s115")) {
+        return sum_a();
+    } else if (!strcmp(name, "s1115")) {
+        return sum_aa();
+    } else if (!strcmp(name, "s116")) {
+        return sum_a();
+    } else if (!strcmp(name, "s118")) {
+        return sum_a();
+    } else if (!strcmp(name, "s119")) {
+        return sum_aa();
+    } else if (!strcmp(name, "s1119")) {
+        return sum_aa();
+    } else if (!strcmp(name, "s121")) {
+        return sum_a();
+    } else if (!strcmp(name, "s122")) {
+        return sum_a();
+    } else if (!strcmp(name, "s123")) {
+        return sum_a();
+    } else if (!strcmp(name, "s124")) {
+        return sum_a();
+    } else if (!strcmp(name, "s125")) {
+        return sum_flat_2d_array();
+    } else if (!strcmp(name, "s126")) {
+        return sum_bb();
+    } else if (!strcmp(name, "s127")) {
+        return sum_a();
+    } else if (!strcmp(name, "s128")) {
+        return sum_a() + sum_b();
+    } else if (!strcmp(name, "s131")) {
+        return sum_a();
+    } else if (!strcmp(name, "s132")) {
+        return sum_aa();
+    } else if (!strcmp(name, "s141")) {
+        return sum_flat_2d_array();
+    } else if (!strcmp(name, "s151")) {
+        return sum_a();
+    } else if (!strcmp(name, "s152")) {
+        return sum_a();
+    } else if (!strcmp(name, "s161")) {
+        return sum_a() + sum_c();
+    } else if (!strcmp(name, "s1161")) {
+        return sum_a() + sum_c();
+    } else if (!strcmp(name, "s162")) {
+        return sum_a();
+    } else if (!strcmp(name, "s171")) {
+        return sum_a();
+    } else if (!strcmp(name, "s172")) {
+        return sum_a();
+    } else if (!strcmp(name, "s173")) {
+        return sum_a();
+    } else if (!strcmp(name, "s174")) {
+        return sum_a();
+    } else if (!strcmp(name, "s175")) {
+        return sum_a();
+    } else if (!strcmp(name, "s176")) {
+        return sum_a();
+    } else if (!strcmp(name, "s211")) {
+        return sum_a() + sum_b();
+    } else if (!strcmp(name, "s212")) {
+        return sum_a() + sum_b();
+    } else if (!strcmp(name, "s1213")) {
+        return sum_a() + sum_b();
+    } else if (!strcmp(name, "s221")) {
+        return sum_a() + sum_b();
+    } else if (!strcmp(name, "s1221")) {
+        return sum_a() + sum_b();
+    } else if (!strcmp(name, "s222")) {
+        return sum_a() + sum_b();
+    } else if (!strcmp(name, "s231")) {
+        return sum_aa();
+    } else if (!strcmp(name, "s232")) {
+        return sum_aa();
+    } else if (!strcmp(name, "s1232")) {
+        return sum_aa();
+    } else if (!strcmp(name, "s233")) {
+        return sum_aa_bb();
+    } else if (!strcmp(name, "s2233")) {
+        return sum_aa_bb();
+    } else if (!strcmp(name, "s235")) {
+        return sum_a() + sum_b();
+    } else if (!strcmp(name, "s241")) {
+        return sum_a() + sum_b();
+    } else if (!strcmp(name, "s242")) {
+        return sum_a();
+    } else if (!strcmp(name, "s243")) {
+        return sum_a() + sum_b();
+    } else if (!strcmp(name, "s244")) {
+        return sum_a() + sum_b();
+    } else if (!strcmp(name, "s1244")) {
+        return sum_a() + sum_b();
+    } else if (!strcmp(name, "s2244")) {
+        return sum_a() + sum_b();
+    } else if (!strcmp(name, "s251")) {
+        return sum_a();
+    } else if (!strcmp(name, "s1251")) {
+        return sum_a();
+    } else if (!strcmp(name, "s2251")) {
+        return sum_a();
+    } else if (!strcmp(name, "s3251")) {
+        return sum_a();
+    } else if (!strcmp(name, "s252")) {
+        return sum_a();
+    } else if (!strcmp(name, "s253")) {
+        return sum_a() + sum_c();
+    } else if (!strcmp(name, "s254")) {
+        return sum_a();
+    } else if (!strcmp(name, "s255")) {
+        return sum_a();
+    } else if (!strcmp(name, "s256")) {
+        return sum_a_aa();
+    } else if (!strcmp(name, "s257")) {
+        return sum_a_aa();
+    } else if (!strcmp(name, "s258")) {
+        return sum_b() + sum_e();
+    } else if (!strcmp(name, "s261")) {
+        return sum_a() + sum_c();
+    } else if (!strcmp(name, "s271")) {
+        return sum_a();
+    } else if (!strcmp(name, "s272")) {
+        return sum_a() + sum_b();
+    } else if (!strcmp(name, "s273")) {
+        return sum_a() + sum_b() + sum_c();
+    } else if (!strcmp(name, "s274")) {
+        return sum_a() + sum_b();
+    } else if (!strcmp(name, "s275")) {
+        return sum_aa();
+    } else if (!strcmp(name, "s2275")) {
+        return sum_aa();
+    } else if (!strcmp(name, "s276")) {
+        return sum_a();
+    } else if (!strcmp(name, "s277")) {
+        return sum_a() + sum_b();
+    } else if (!strcmp(name, "s278")) {
+        return sum_a() + sum_b() + sum_c();
+    } else if (!strcmp(name, "s279")) {
+        return sum_a() + sum_b() + sum_c();
+    } else if (!strcmp(name, "s1279")) {
+        return sum_a() + sum_b() + sum_c();
+    } else if (!strcmp(name, "s2710")) {
+        return sum_a() + sum_b() + sum_c();
+    } else if (!strcmp(name, "s2711")) {
+        return sum_a();
+    } else if (!strcmp(name, "s2712")) {
+        return sum_a();
+    } else if (!strcmp(name, "s281")) {
+        return sum_a() + sum_b();
+    } else if (!strcmp(name, "s1281")) {
+        return sum_a() + sum_b();
+    } else if (!strcmp(name, "s291")) {
+        return sum_a();
+    } else if (!strcmp(name, "s292")) {
+        return sum_a();
+    } else if (!strcmp(name, "s293")) {
+        return sum_a();
+    } else if (!strcmp(name, "s2101")) {
+        return sum_aa();
+    } else if (!strcmp(name, "s2102")) {
+        return sum_aa();
+    } else if (!strcmp(name, "s2111")) {
+        return sum_aa();
+    } else if (!strcmp(name, "s311")) {
+        return sum_a();
+    } else if (!strcmp(name, "s31111")) {
+        return sum_a();
+    } else if (!strcmp(name, "s321")) {
+        return sum_a();
+    } else if (!strcmp(name, "s322")) {
+        return sum_a();
+    } else if (!strcmp(name, "s323")) {
+        return sum_a() + sum_b();
+    } else if (!strcmp(name, "s341")) {
+        return sum_a();
+    } else if (!strcmp(name, "s342")) {
+        return sum_a();
+    } else if (!strcmp(name, "s343")) {
+        return sum_flat_2d_array();
+    } else if (!strcmp(name, "s351")) {
+        return sum_a();
+    } else if (!strcmp(name, "s1351")) {
+        return sum_a();
+    } else if (!strcmp(name, "s353")) {
+        return sum_a();
+    } else if (!strcmp(name, "s421")) {
+        return sum_xx();
+    } else if (!strcmp(name, "s1421")) {
+        return sum_half_xx();
+    } else if (!strcmp(name, "s422")) {
+        return sum_xx();
+    } else if (!strcmp(name, "s423")) {
+        return sum_flat_2d_array();
+    } else if (!strcmp(name, "s424")) {
+        return sum_xx();
+    } else if (!strcmp(name, "s431")) {
+        return sum_a();
+    } else if (!strcmp(name, "s441")) {
+        return sum_a();
+    } else if (!strcmp(name, "s442")) {
+        return sum_a();
+    } else if (!strcmp(name, "s443")) {
+        return sum_a();
+    } else if (!strcmp(name, "s451")) {
+        return sum_a();
+    } else if (!strcmp(name, "s452")) {
+        return sum_a();
+    } else if (!strcmp(name, "s453")) {
+        return sum_a();
+    } else if (!strcmp(name, "s471")) {
+        return sum_x() + sum_b();
+    } else if (!strcmp(name, "s481")) {
+        return sum_a();
+    } else if (!strcmp(name, "s482")) {
+        return sum_a();
+    } else if (!strcmp(name, "s491")) {
+        return sum_a();
+    } else if (!strcmp(name, "s4112")) {
+        return sum_a();
+    } else if (!strcmp(name, "s4113")) {
+        return sum_a();
+    } else if (!strcmp(name, "s4114")) {
+        return sum_a();
+    } else if (!strcmp(name, "s4117")) {
+        return sum_a();
+    } else if (!strcmp(name, "s4121")) {
+        return sum_a();
+    } else if (!strcmp(name, "va")) {
+        return sum_a();
+    } else if (!strcmp(name, "vag")) {
+        return sum_a();
+    } else if (!strcmp(name, "vas")) {
+        return sum_a();
+    } else if (!strcmp(name, "vif")) {
+        return sum_a();
+    } else if (!strcmp(name, "vpv")) {
+        return sum_a();
+    } else if (!strcmp(name, "vtv")) {
+        return sum_a();
+    } else if (!strcmp(name, "vpvtv")) {
+        return sum_a();
+    } else if (!strcmp(name, "vpvts")) {
+        return sum_a();
+    } else if (!strcmp(name, "vpvpv")) {
+        return sum_a();
+    } else if (!strcmp(name, "vtvtv")) {
+        return sum_a();
+    } else if (!strcmp(name, "vsumr")) {
+        return sum_a();
+    } else if (!strcmp(name, "vbor")) {
+        return sum_x();
+    } else {
+        printf("Unknown function name passed to calc_checksum: %s\n", name);
+        // fprintf(stderr, "Unknown function name passed to calc_checksum: %s\n", name);
+        exit(1);
+    }
+    return 0;
+}
+

--- a/apps/tsvc/src/common.c
+++ b/apps/tsvc/src/common.c
@@ -1030,7 +1030,7 @@ real_t calc_checksum(const char * name)
     } else {
         printf("Unknown function name passed to calc_checksum: %s\n", name);
         // fprintf(stderr, "Unknown function name passed to calc_checksum: %s\n", name);
-        exit(1);
+        _halt(1);
     }
     return 0;
 }

--- a/apps/tsvc/src/dummy.c
+++ b/apps/tsvc/src/dummy.c
@@ -1,0 +1,8 @@
+
+#include "common.h"
+
+int dummy(float a[LEN_1D], float b[LEN_1D], float c[LEN_1D], float d[LEN_1D], float e[LEN_1D], float aa[LEN_2D][LEN_2D], float bb[LEN_2D][LEN_2D], float cc[LEN_2D][LEN_2D], float s){
+    // --  called in each loop to make all computations appear required
+    return 0;
+}
+

--- a/apps/tsvc/src/tsvc.c
+++ b/apps/tsvc/src/tsvc.c
@@ -3379,7 +3379,7 @@ real_t s481(struct args_t * func_args)
     for (int nl = 0; nl < iterations; nl++) {
         for (int i = 0; i < LEN_1D; i++) {
             if (d[i] < (real_t)0.) {
-                exit (0);
+                _halt (0);
             }
             a[i] += b[i] * c[i];
         }

--- a/apps/tsvc/src/tsvc.c
+++ b/apps/tsvc/src/tsvc.c
@@ -1,0 +1,4133 @@
+
+/*
+ * This is an executable test containing a number of loops to measure
+ * the performance of a compiler. Arrays' length is LEN_1D by default
+ * and if you want a different array length, you should replace every
+ * LEN_1D by your desired number which must be a multiple of 40. If you
+ * want to increase the number of loop calls to have a longer run time
+ * you have to manipulate the constant value iterations. There is a dummy
+ * function called in each loop to make all computations appear required.
+ * The time to execute this function is included in the time measurement
+ * for the output but it is neglectable.
+ *
+ *  The output includes three columns:
+ *    Loop:        The name of the loop
+ *    Time(Sec):     The time in seconds to run the loop
+ *    Checksum:    The checksum calculated when the test has run
+ *
+ * In this version of the codelets arrays are static type.
+ *
+ * All functions/loops are taken from "TEST SUITE FOR VECTORIZING COMPILERS"
+ * by David Callahan, Jack Dongarra and David Levine except those whose
+ * functions' name have 4 digits.
+ */
+
+// #include <time.h>
+// #include <stdio.h>
+// #include <stdlib.h>
+// #include <math.h>
+// #include <sys/time.h>
+
+#include "common.h"
+#include "array_defs.h"
+
+#define INIT() \
+do{ \
+    asm volatile ( \
+        "lui a0,0x2\n" \
+        "addiw a0,a0,512\n" \
+        "csrs mstatus,a0\n" \
+        "csrwi vcsr,0"\
+        :: \
+    ); \
+} while (0)
+
+// array definitions
+__attribute__((aligned(ARRAY_ALIGNMENT))) real_t flat_2d_array[LEN_2D*LEN_2D];
+
+__attribute__((aligned(ARRAY_ALIGNMENT))) real_t x[LEN_1D];
+
+__attribute__((aligned(ARRAY_ALIGNMENT))) real_t a[LEN_1D],b[LEN_1D],c[LEN_1D],d[LEN_1D],e[LEN_1D],
+                                   aa[LEN_2D][LEN_2D],bb[LEN_2D][LEN_2D],cc[LEN_2D][LEN_2D],tt[LEN_2D][LEN_2D];
+
+__attribute__((aligned(ARRAY_ALIGNMENT))) int indx[LEN_1D];
+
+real_t* __restrict__ xx;
+real_t* yy;
+
+real_t s000(struct args_t * func_args)
+{
+
+//    linear dependence testing
+//    no dependence - vectorizable
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 2*iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            a[i] = b[i] + 1;
+        }
+        dummy((real_t*)a, (real_t*)b, (real_t*)c, (real_t*)d, (real_t*)e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %1.1
+real_t s111(struct args_t * func_args)
+{
+
+//    linear dependence testing
+//    no dependence - vectorizable
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 2*iterations; nl++) {
+        for (int i = 1; i < LEN_1D; i += 2) {
+            a[i] = a[i - 1] + b[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+real_t s1111(struct args_t * func_args)
+{
+
+//    no dependence - vectorizable
+//    jump in data access
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 2*iterations; nl++) {
+        for (int i = 0; i < LEN_1D/2; i++) {
+            a[2*i] = c[i] * b[i] + d[i] * b[i] + c[i] * c[i] + d[i] * b[i] + d[i] * c[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %1.1
+
+real_t s112(struct args_t * func_args)
+{
+
+//    linear dependence testing
+//    loop reversal
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 3*iterations; nl++) {
+        for (int i = LEN_1D - 2; i >= 0; i--) {
+            a[i+1] = a[i] + b[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+real_t s1112(struct args_t * func_args)
+{
+
+//    linear dependence testing
+//    loop reversal
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations*3; nl++) {
+        for (int i = LEN_1D - 1; i >= 0; i--) {
+            a[i] = b[i] + (real_t) 1.;
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %1.1
+
+real_t s113(struct args_t * func_args)
+{
+
+//    linear dependence testing
+//    a(i)=a(1) but no actual dependence cycle
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 4*iterations; nl++) {
+        for (int i = 1; i < LEN_1D; i++) {
+            a[i] = a[0] + b[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+real_t s1113(struct args_t * func_args)
+{
+
+//    linear dependence testing
+//    one iteration dependency on a(LEN_1D/2) but still vectorizable
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 2*iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            a[i] = a[LEN_1D/2] + b[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %1.1
+
+real_t s114(struct args_t * func_args)
+{
+
+//    linear dependence testing
+//    transpose vectorization
+//    Jump in data access - not vectorizable
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 200*(iterations/(LEN_2D)); nl++) {
+        for (int i = 0; i < LEN_2D; i++) {
+            for (int j = 0; j < i; j++) {
+                aa[i][j] = aa[j][i] + bb[i][j];
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %1.1
+
+real_t s115(struct args_t * func_args)
+{
+
+//    linear dependence testing
+//    triangular saxpy loop
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 1000*(iterations/LEN_2D); nl++) {
+        for (int j = 0; j < LEN_2D; j++) {
+            for (int i = j+1; i < LEN_2D; i++) {
+                a[i] -= aa[j][i] * a[j];
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+real_t s1115(struct args_t * func_args)
+{
+
+//    linear dependence testing
+//    triangular saxpy loop
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 100*(iterations/LEN_2D); nl++) {
+        for (int i = 0; i < LEN_2D; i++) {
+            for (int j = 0; j < LEN_2D; j++) {
+                aa[i][j] = aa[i][j]*cc[j][i] + bb[i][j];
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %1.1
+
+real_t s116(struct args_t * func_args)
+{
+
+//    linear dependence testing
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations*10; nl++) {
+        for (int i = 0; i < LEN_1D - 5; i += 5) {
+            a[i] = a[i + 1] * a[i];
+            a[i + 1] = a[i + 2] * a[i + 1];
+            a[i + 2] = a[i + 3] * a[i + 2];
+            a[i + 3] = a[i + 4] * a[i + 3];
+            a[i + 4] = a[i + 5] * a[i + 4];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %1.1
+
+real_t s118(struct args_t * func_args)
+{
+
+//    linear dependence testing
+//    potential dot product recursion
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 200*(iterations/LEN_2D); nl++) {
+        for (int i = 1; i < LEN_2D; i++) {
+            for (int j = 0; j <= i - 1; j++) {
+                a[i] += bb[j][i] * a[i-j-1];
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %1.1
+
+real_t s119(struct args_t * func_args)
+{
+
+//    linear dependence testing
+//    no dependence - vectorizable
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 200*(iterations/(LEN_2D)); nl++) {
+        for (int i = 1; i < LEN_2D; i++) {
+            for (int j = 1; j < LEN_2D; j++) {
+                aa[i][j] = aa[i-1][j-1] + bb[i][j];
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+real_t s1119(struct args_t * func_args)
+{
+
+//    linear dependence testing
+//    no dependence - vectorizable
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 200*(iterations/(LEN_2D)); nl++) {
+        for (int i = 1; i < LEN_2D; i++) {
+            for (int j = 0; j < LEN_2D; j++) {
+                aa[i][j] = aa[i-1][j] + bb[i][j];
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %1.2
+
+real_t s121(struct args_t * func_args)
+{
+
+//    induction variable recognition
+//    loop with possible ambiguity because of scalar store
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    int j;
+    for (int nl = 0; nl < 3*iterations; nl++) {
+        for (int i = 0; i < LEN_1D-1; i++) {
+            j = i + 1;
+            a[i] = a[j] + b[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %1.2
+
+real_t s122(struct args_t * func_args)
+{
+
+//    induction variable recognition
+//    variable lower and upper bound, and stride
+//    reverse data access and jump in data access
+
+    struct{int a;int b;} * x = func_args->arg_info;
+    int n1 = x->a;
+    int n3 = x->b;
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    int j, k;
+    for (int nl = 0; nl < iterations; nl++) {
+        j = 1;
+        k = 0;
+        for (int i = n1-1; i < LEN_1D; i += n3) {
+            k += j;
+            a[i] += b[LEN_1D - k];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %1.2
+
+real_t s123(struct args_t * func_args)
+{
+
+//    induction variable recognition
+//    induction variable under an if
+//    not vectorizable, the condition cannot be speculated
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    int j;
+    for (int nl = 0; nl < iterations; nl++) {
+        j = -1;
+        for (int i = 0; i < (LEN_1D/2); i++) {
+            j++;
+            a[j] = b[i] + d[i] * e[i];
+            if (c[i] > (real_t)0.) {
+                j++;
+                a[j] = c[i] + d[i] * e[i];
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %1.2
+
+real_t s124(struct args_t * func_args)
+{
+
+//    induction variable recognition
+//    induction variable under both sides of if (same value)
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    int j;
+    for (int nl = 0; nl < iterations; nl++) {
+        j = -1;
+        for (int i = 0; i < LEN_1D; i++) {
+            if (b[i] > (real_t)0.) {
+                j++;
+                a[j] = b[i] + d[i] * e[i];
+            } else {
+                j++;
+                a[j] = c[i] + d[i] * e[i];
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %1.2
+real_t s125(struct args_t * func_args)
+{
+
+//    induction variable recognition
+//    induction variable in two loops; collapsing possible
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    int k;
+    for (int nl = 0; nl < 100*(iterations/(LEN_2D)); nl++) {
+        k = -1;
+        for (int i = 0; i < LEN_2D; i++) {
+            for (int j = 0; j < LEN_2D; j++) {
+                k++;
+                flat_2d_array[k] = aa[i][j] + bb[i][j] * cc[i][j];
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %1.2
+real_t s126(struct args_t * func_args)
+{
+
+//    induction variable recognition
+//    induction variable in two loops; recurrence in inner loop
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    int k;
+    for (int nl = 0; nl < 10*(iterations/LEN_2D); nl++) {
+        k = 1;
+        for (int i = 0; i < LEN_2D; i++) {
+            for (int j = 1; j < LEN_2D; j++) {
+                bb[j][i] = bb[j-1][i] + flat_2d_array[k-1] * cc[j][i];
+                ++k;
+            }
+            ++k;
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %1.2
+
+real_t s127(struct args_t * func_args)
+{
+
+//    induction variable recognition
+//    induction variable with multiple increments
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    int j;
+    for (int nl = 0; nl < 2*iterations; nl++) {
+        j = -1;
+        for (int i = 0; i < LEN_1D/2; i++) {
+            j++;
+            a[j] = b[i] + c[i] * d[i];
+            j++;
+            a[j] = b[i] + d[i] * e[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %1.2
+
+real_t s128(struct args_t * func_args)
+{
+
+//    induction variables
+//    coupled induction variables
+//    jump in data access
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    int j, k;
+    for (int nl = 0; nl < 2*iterations; nl++) {
+        j = -1;
+        for (int i = 0; i < LEN_1D/2; i++) {
+            k = j + 1;
+            a[i] = b[k] - d[i];
+            j = k + 1;
+            b[k] = a[i] + c[k];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 1.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %1.3
+
+real_t s131(struct args_t * func_args)
+{
+//    global data flow analysis
+//    forward substitution
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    int m  = 1;
+    for (int nl = 0; nl < 5*iterations; nl++) {
+        for (int i = 0; i < LEN_1D - 1; i++) {
+            a[i] = a[i + m] + b[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %1.3
+
+real_t s132(struct args_t * func_args)
+{
+//    global data flow analysis
+//    loop with multiple dimension ambiguous subscripts
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    int m = 0;
+    int j = m;
+    int k = m+1;
+    for (int nl = 0; nl < 400*iterations; nl++) {
+        for (int i= 1; i < LEN_2D; i++) {
+            aa[j][i] = aa[k][i-1] + b[i] * c[1];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %1.4
+
+real_t s141(struct args_t * func_args)
+{
+
+//    nonlinear dependence testing
+//    walk a row in a symmetric packed array
+//    element a(i,j) for (int j>i) stored in location j*(j-1)/2+i
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    int k;
+    for (int nl = 0; nl < 200*(iterations/LEN_2D); nl++) {
+        for (int i = 0; i < LEN_2D; i++) {
+            k = (i+1) * ((i+1) - 1) / 2 + (i+1)-1;
+            for (int j = i; j < LEN_2D; j++) {
+                flat_2d_array[k] += bb[j][i];
+                k += j+1;
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %1.5
+
+void s151s(real_t a[LEN_1D], real_t b[LEN_1D],  int m)
+{
+    for (int i = 0; i < LEN_1D-1; i++) {
+        a[i] = a[i + m] + b[i];
+    }
+}
+
+real_t s151(struct args_t * func_args)
+{
+
+//    interprocedural data flow analysis
+//    passing parameter information into a subroutine
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 5*iterations; nl++) {
+        s151s(a, b,  1);
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %1.5
+
+void s152s(real_t a[LEN_1D], real_t b[LEN_1D], real_t c[LEN_1D], int i)
+{
+    a[i] += b[i] * c[i];
+}
+
+real_t s152(struct args_t * func_args)
+{
+
+//    interprocedural data flow analysis
+//    collecting information from a subroutine
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            b[i] = d[i] * e[i];
+            s152s(a, b, c, i);
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %1.6
+
+real_t s161(struct args_t * func_args)
+{
+
+//    control flow
+//    tests for recognition of loop independent dependences
+//    between statements in mutually exclusive regions.
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations/2; nl++) {
+        for (int i = 0; i < LEN_1D-1; ++i) {
+            if (b[i] < (real_t)0.) {
+                goto L20;
+            }
+            a[i] = c[i] + d[i] * e[i];
+            goto L10;
+L20:
+            c[i+1] = a[i] + d[i] * d[i];
+L10:
+            ;
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+real_t s1161(struct args_t * func_args)
+{
+
+//    control flow
+//    tests for recognition of loop independent dependences
+//    between statements in mutually exclusive regions.
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = 0; i < LEN_1D-1; ++i) {
+            if (c[i] < (real_t)0.) {
+                goto L20;
+            }
+            a[i] = c[i] + d[i] * e[i];
+            goto L10;
+L20:
+            b[i] = a[i] + d[i] * d[i];
+L10:
+            ;
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %1.6
+
+//int s162(int k)
+real_t s162(struct args_t * func_args)
+{
+//    control flow
+//    deriving assertions
+
+    int k = *(int*)func_args->arg_info;
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations; nl++) {
+        if (k > 0) {
+            for (int i = 0; i < LEN_1D-1; i++) {
+                a[i] = a[i + k] + b[i] * c[i];
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %1.7
+
+//int s171(int inc)
+real_t s171(struct args_t * func_args)
+{
+
+//    symbolics
+//    symbolic dependence tests
+
+    int inc = *(int*)func_args->arg_info;
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            a[i * inc] += b[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %1.7
+
+//int s172( int n1, int n3)
+real_t s172(struct args_t * func_args)
+{
+//    symbolics
+//    vectorizable if n3 .ne. 0
+
+    struct{int a;int b;} * x = func_args->arg_info;
+    int n1 = x->a;
+    int n3 = x->b;
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = n1-1; i < LEN_1D; i += n3) {
+            a[i] += b[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %1.7
+
+real_t s173(struct args_t * func_args)
+{
+//    symbolics
+//    expression in loop bounds and subscripts
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    int k = LEN_1D/2;
+    for (int nl = 0; nl < 10*iterations; nl++) {
+        for (int i = 0; i < LEN_1D/2; i++) {
+            a[i+k] = a[i] + b[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %1.7
+
+//int s174(int M)
+real_t s174(struct args_t * func_args)
+{
+
+//    symbolics
+//    loop with subscript that may seem ambiguous
+
+    int M = *(int*)func_args->arg_info;
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 10*iterations; nl++) {
+        for (int i = 0; i < M; i++) {
+            a[i+M] = a[i] + b[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %1.7
+
+//int s175(int inc)
+real_t s175(struct args_t * func_args)
+{
+
+//    symbolics
+//    symbolic dependence tests
+
+    int inc = *(int*)func_args->arg_info;
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = 0; i < LEN_1D-1; i += inc) {
+            a[i] = a[i + inc] + b[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %1.7
+
+real_t s176(struct args_t * func_args)
+{
+
+//    symbolics
+//    convolution
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    int m = LEN_1D/2;
+    for (int nl = 0; nl < 4*(iterations/LEN_1D); nl++) {
+        for (int j = 0; j < (LEN_1D/2); j++) {
+            for (int i = 0; i < m; i++) {
+                a[i] += b[i+m-j-1] * c[j];
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// **********************************************************
+// *                                *
+// *            VECTORIZATION                *
+// *                                *
+// **********************************************************
+
+// %2.1
+
+real_t s211(struct args_t * func_args)
+{
+
+//    statement reordering
+//    statement reordering allows vectorization
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = 1; i < LEN_1D-1; i++) {
+            a[i] = b[i - 1] + c[i] * d[i];
+            b[i] = b[i + 1] - e[i] * d[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.1
+
+real_t s212(struct args_t * func_args)
+{
+
+//    statement reordering
+//    dependency needing temporary
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = 0; i < LEN_1D-1; i++) {
+            a[i] *= c[i];
+            b[i] += a[i + 1] * d[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+real_t s1213(struct args_t * func_args)
+{
+
+//    statement reordering
+//    dependency needing temporary
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = 1; i < LEN_1D-1; i++) {
+            a[i] = b[i-1]+c[i];
+            b[i] = a[i+1]*d[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.2
+
+real_t s221(struct args_t * func_args)
+{
+
+//    loop distribution
+//    loop that is partially recursive
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations/2; nl++) {
+        for (int i = 1; i < LEN_1D; i++) {
+            a[i] += c[i] * d[i];
+            b[i] = b[i - 1] + a[i] + d[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+real_t s1221(struct args_t * func_args)
+{
+
+//    run-time symbolic resolution
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = 4; i < LEN_1D; i++) {
+            b[i] = b[i - 4] + a[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.2
+
+real_t s222(struct args_t * func_args)
+{
+
+//    loop distribution
+//    partial loop vectorizatio recurrence in middle
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations/2; nl++) {
+        for (int i = 1; i < LEN_1D; i++) {
+            a[i] += b[i] * c[i];
+            e[i] = e[i - 1] * e[i - 1];
+            a[i] -= b[i] * c[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.3
+
+real_t s231(struct args_t * func_args)
+{
+//    loop interchange
+//    loop with data dependency
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 100*(iterations/LEN_2D); nl++) {
+        for (int i = 0; i < LEN_2D; ++i) {
+            for (int j = 1; j < LEN_2D; j++) {
+                aa[j][i] = aa[j - 1][i] + bb[j][i];
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.3
+
+real_t s232(struct args_t * func_args)
+{
+
+//    loop interchange
+//    interchanging of triangular loops
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 100*(iterations/(LEN_2D)); nl++) {
+        for (int j = 1; j < LEN_2D; j++) {
+            for (int i = 1; i <= j; i++) {
+                aa[j][i] = aa[j][i-1]*aa[j][i-1]+bb[j][i];
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 1.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+real_t s1232(struct args_t * func_args)
+{
+
+//    loop interchange
+//    interchanging of triangular loops
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 100*(iterations/LEN_2D); nl++) {
+        for (int j = 0; j < LEN_2D; j++) {
+            for (int i = j; i < LEN_2D; i++) {
+                aa[i][j] = bb[i][j] + cc[i][j];
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 1.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.3
+
+real_t s233(struct args_t * func_args)
+{
+
+//    loop interchange
+//    interchanging with one of two inner loops
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 100*(iterations/LEN_2D); nl++) {
+        for (int i = 1; i < LEN_2D; i++) {
+            for (int j = 1; j < LEN_2D; j++) {
+                aa[j][i] = aa[j-1][i] + cc[j][i];
+            }
+            for (int j = 1; j < LEN_2D; j++) {
+                bb[j][i] = bb[j][i-1] + cc[j][i];
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+real_t s2233(struct args_t * func_args)
+{
+
+//    loop interchange
+//    interchanging with one of two inner loops
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 100*(iterations/LEN_2D); nl++) {
+        for (int i = 1; i < LEN_2D; i++) {
+            for (int j = 1; j < LEN_2D; j++) {
+                aa[j][i] = aa[j-1][i] + cc[j][i];
+            }
+            for (int j = 1; j < LEN_2D; j++) {
+                bb[i][j] = bb[i-1][j] + cc[i][j];
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.3
+real_t s235(struct args_t * func_args)
+{
+
+//    loop interchanging
+//    imperfectly nested loops
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 200*(iterations/LEN_2D); nl++) {
+        for (int i = 0; i < LEN_2D; i++) {
+            a[i] += b[i] * c[i];
+            for (int j = 1; j < LEN_2D; j++) {
+                aa[j][i] = aa[j-1][i] + bb[j][i] * a[i];
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.4
+
+real_t s241(struct args_t * func_args)
+{
+
+//    node splitting
+//    preloading necessary to allow vectorization
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 2*iterations; nl++) {
+        for (int i = 0; i < LEN_1D-1; i++) {
+            a[i] = b[i] * c[i  ] * d[i];
+            b[i] = a[i] * a[i+1] * d[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.4
+
+//int s242(real_t s1, real_t s2)
+real_t s242(struct args_t * func_args)
+{
+
+//    node splitting
+
+    struct{real_t a;real_t b;} * x = func_args->arg_info;
+    real_t s1 = x->a;
+    real_t s2 = x->b;
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations/5; nl++) {
+        for (int i = 1; i < LEN_1D; ++i) {
+            a[i] = a[i - 1] + s1 + s2 + b[i] + c[i] + d[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.4
+
+real_t s243(struct args_t * func_args)
+{
+
+//    node splitting
+//    false dependence cycle breaking
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = 0; i < LEN_1D-1; i++) {
+            a[i] = b[i] + c[i  ] * d[i];
+            b[i] = a[i] + d[i  ] * e[i];
+            a[i] = b[i] + a[i+1] * d[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.4
+
+real_t s244(struct args_t * func_args)
+{
+
+//    node splitting
+//    false dependence cycle breaking
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = 0; i < LEN_1D-1; ++i) {
+            a[i] = b[i] + c[i] * d[i];
+            b[i] = c[i] + b[i];
+            a[i+1] = b[i] + a[i+1] * d[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+real_t s1244(struct args_t * func_args)
+{
+
+//    node splitting
+//    cycle with ture and anti dependency
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = 0; i < LEN_1D-1; i++) {
+            a[i] = b[i] + c[i] * c[i] + b[i]*b[i] + c[i];
+            d[i] = a[i] + a[i+1];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+real_t s2244(struct args_t * func_args)
+{
+
+//    node splitting
+//    cycle with ture and anti dependency
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = 0; i < LEN_1D-1; i++) {
+            a[i+1] = b[i] + e[i];
+            a[i] = b[i] + c[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.5
+
+real_t s251(struct args_t * func_args)
+{
+
+//    scalar and array expansion
+//    scalar expansion
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    real_t s;
+    for (int nl = 0; nl < 4*iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            s = b[i] + c[i] * d[i];
+            a[i] = s * s;
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+real_t s1251(struct args_t * func_args)
+{
+
+//    scalar and array expansion
+//    scalar expansion
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    real_t s;
+    for (int nl = 0; nl < 4*iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            s = b[i]+c[i];
+            b[i] = a[i]+d[i];
+            a[i] = s*e[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+real_t s2251(struct args_t * func_args)
+{
+
+//    scalar and array expansion
+//    scalar expansion
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations; nl++) {
+        real_t s = (real_t)0.0;
+        for (int i = 0; i < LEN_1D; i++) {
+            a[i] = s*e[i];
+            s = b[i]+c[i];
+            b[i] = a[i]+d[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+real_t s3251(struct args_t * func_args)
+{
+
+//    scalar and array expansion
+//    scalar expansion
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = 0; i < LEN_1D-1; i++){
+            a[i+1] = b[i]+c[i];
+            b[i]   = c[i]*e[i];
+            d[i]   = a[i]*e[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.5
+
+real_t s252(struct args_t * func_args)
+{
+
+//    scalar and array expansion
+//    loop with ambiguous scalar temporary
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    real_t t, s;
+    for (int nl = 0; nl < iterations; nl++) {
+        t = (real_t) 0.;
+        for (int i = 0; i < LEN_1D; i++) {
+            s = b[i] * c[i];
+            a[i] = s + t;
+            t = s;
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.5
+
+real_t s253(struct args_t * func_args)
+{
+
+//    scalar and array expansion
+//    scalar expansio assigned under if
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    real_t s;
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            if (a[i] > b[i]) {
+                s = a[i] - b[i] * d[i];
+                c[i] += s;
+                a[i] = s;
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.5
+
+real_t s254(struct args_t * func_args)
+{
+
+//    scalar and array expansion
+//    carry around variable
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    real_t x;
+    for (int nl = 0; nl < 4*iterations; nl++) {
+        x = b[LEN_1D-1];
+        for (int i = 0; i < LEN_1D; i++) {
+            a[i] = (b[i] + x) * (real_t).5;
+            x = b[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.5
+
+real_t s255(struct args_t * func_args)
+{
+
+//    scalar and array expansion
+//    carry around variables, 2 levels
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    real_t x, y;
+    for (int nl = 0; nl < iterations; nl++) {
+        x = b[LEN_1D-1];
+        y = b[LEN_1D-2];
+        for (int i = 0; i < LEN_1D; i++) {
+            a[i] = (b[i] + x + y) * (real_t).333;
+            y = x;
+            x = b[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.5
+
+real_t s256(struct args_t * func_args)
+{
+
+//    scalar and array expansion
+//    array expansion
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 10*(iterations/LEN_2D); nl++) {
+        for (int i = 0; i < LEN_2D; i++) {
+            for (int j = 1; j < LEN_2D; j++) {
+                a[j] = (real_t)1.0 - a[j - 1];
+                aa[j][i] = a[j] + bb[j][i]*d[j];
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.5
+
+real_t s257(struct args_t * func_args)
+{
+
+//    scalar and array expansion
+//    array expansion
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 10*(iterations/LEN_2D); nl++) {
+        for (int i = 1; i < LEN_2D; i++) {
+            for (int j = 0; j < LEN_2D; j++) {
+                a[i] = aa[j][i] - a[i-1];
+                aa[j][i] = a[i] + bb[j][i];
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+real_t s258(struct args_t * func_args)
+{
+
+//    scalar and array expansion
+//    wrap-around scalar under an if
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    real_t s;
+    for (int nl = 0; nl < iterations; nl++) {
+        s = 0.;
+        for (int i = 0; i < LEN_2D; ++i) {
+            if (a[i] > 0.) {
+                s = d[i] * d[i];
+            }
+            b[i] = s * c[i] + d[i];
+            e[i] = (s + (real_t)1.) * aa[0][i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.7
+
+real_t s261(struct args_t * func_args)
+{
+
+//    scalar and array expansion
+//    wrap-around scalar under an if
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    real_t t;
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = 1; i < LEN_1D; ++i) {
+            t = a[i] + b[i];
+            a[i] = t + c[i-1];
+            t = c[i] * d[i];
+            c[i] = t;
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+real_t s271(struct args_t * func_args)
+{
+
+//    control flow
+//    loop with singularity handling
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 4*iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            if (b[i] > (real_t)0.) {
+                a[i] += b[i] * c[i];
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.7
+
+//int s272(real_t t)
+real_t s272(struct args_t * func_args)
+{
+
+//    control flow
+//    loop with independent conditional
+
+    int t = *(int*)func_args->arg_info;
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            if (e[i] >= t) {
+                a[i] += c[i] * d[i];
+                b[i] += c[i] * c[i];
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.7
+
+real_t s273(struct args_t * func_args)
+{
+
+//    control flow
+//    simple loop with dependent conditional
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            a[i] += d[i] * e[i];
+            if (a[i] < (real_t)0.)
+                b[i] += d[i] * e[i];
+            c[i] += a[i] * d[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.7
+
+real_t s274(struct args_t * func_args)
+{
+
+//    control flow
+//    complex loop with dependent conditional
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            a[i] = c[i] + e[i] * d[i];
+            if (a[i] > (real_t)0.) {
+                b[i] = a[i] + b[i];
+            } else {
+                a[i] = d[i] * e[i];
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.7
+
+real_t s275(struct args_t * func_args)
+{
+
+//    control flow
+//    if around inner loop, interchanging needed
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 10*(iterations/LEN_2D); nl++) {
+        for (int i = 0; i < LEN_2D; i++) {
+            if (aa[0][i] > (real_t)0.) {
+                for (int j = 1; j < LEN_2D; j++) {
+                    aa[j][i] = aa[j-1][i] + bb[j][i] * cc[j][i];
+                }
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+real_t s2275(struct args_t * func_args)
+{
+
+//    loop distribution is needed to be able to interchange
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 100*(iterations/LEN_2D); nl++) {
+        for (int i = 0; i < LEN_2D; i++) {
+            for (int j = 0; j < LEN_2D; j++) {
+                aa[j][i] = aa[j][i] + bb[j][i] * cc[j][i];
+            }
+            a[i] = b[i] + c[i] * d[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.7
+
+real_t s276(struct args_t * func_args)
+{
+
+//    control flow
+//    if test using loop index
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    int mid = (LEN_1D/2);
+    for (int nl = 0; nl < 4*iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            if (i+1 < mid) {
+                a[i] += b[i] * c[i];
+            } else {
+                a[i] += b[i] * d[i];
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.7
+real_t s277(struct args_t * func_args)
+{
+
+//    control flow
+//    test for dependences arising from guard variable computation.
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = 0; i < LEN_1D-1; i++) {
+                if (a[i] >= (real_t)0.) {
+                    goto L20;
+                }
+                if (b[i] >= (real_t)0.) {
+                    goto L30;
+                }
+                a[i] += c[i] * d[i];
+L30:
+                b[i+1] = c[i] + d[i] * e[i];
+L20:
+;
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.7
+
+real_t s278(struct args_t * func_args)
+{
+
+//    control flow
+//    if/goto to block if-then-else
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            if (a[i] > (real_t)0.) {
+                goto L20;
+            }
+            b[i] = -b[i] + d[i] * e[i];
+            goto L30;
+L20:
+            c[i] = -c[i] + d[i] * e[i];
+L30:
+            a[i] = b[i] + c[i] * d[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.7
+
+real_t s279(struct args_t * func_args)
+{
+
+//    control flow
+//    vector if/gotos
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations/2; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            if (a[i] > (real_t)0.) {
+                goto L20;
+            }
+            b[i] = -b[i] + d[i] * d[i];
+            if (b[i] <= a[i]) {
+                goto L30;
+            }
+            c[i] += d[i] * e[i];
+            goto L30;
+L20:
+            c[i] = -c[i] + e[i] * e[i];
+L30:
+            a[i] = b[i] + c[i] * d[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+real_t s1279(struct args_t * func_args)
+{
+
+//    control flow
+//    vector if/gotos
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            if (a[i] < (real_t)0.) {
+                if (b[i] > a[i]) {
+                    c[i] += d[i] * e[i];
+                }
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.7
+
+//int s2710( real_t x)
+real_t s2710(struct args_t * func_args)
+{
+
+//    control flow
+//    scalar and vector ifs
+
+    int x = *(int*)func_args->arg_info;
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations/2; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            if (a[i] > b[i]) {
+                a[i] += b[i] * d[i];
+                if (LEN_1D > 10) {
+                    c[i] += d[i] * d[i];
+                } else {
+                    c[i] = d[i] * e[i] + (real_t)1.;
+                }
+            } else {
+                b[i] = a[i] + e[i] * e[i];
+                if (x > (real_t)0.) {
+                    c[i] = a[i] + d[i] * d[i];
+                } else {
+                    c[i] += e[i] * e[i];
+                }
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.7
+
+real_t s2711(struct args_t * func_args)
+{
+
+//    control flow
+//    semantic if removal
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 4*iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            if (b[i] != (real_t)0.0) {
+                a[i] += b[i] * c[i];
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.7
+
+real_t s2712(struct args_t * func_args)
+{
+
+//    control flow
+//    if to elemental min
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 4*iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            if (a[i] > b[i]) {
+                a[i] += b[i] * c[i];
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.8
+
+real_t s281(struct args_t * func_args)
+{
+
+//    crossing thresholds
+//    index set splitting
+//    reverse data access
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    real_t x;
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            x = a[LEN_1D-i-1] + b[i] * c[i];
+            a[i] = x-(real_t)1.0;
+            b[i] = x;
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+real_t s1281(struct args_t * func_args)
+{
+
+//    crossing thresholds
+//    index set splitting
+//    reverse data access
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    real_t x;
+    for (int nl = 0; nl < 4*iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            x = b[i]*c[i] + a[i]*d[i] + e[i];
+            a[i] = x-(real_t)1.0;
+            b[i] = x;
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.9
+
+real_t s291(struct args_t * func_args)
+{
+
+//    loop peeling
+//    wrap around variable, 1 level
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    int im1;
+    for (int nl = 0; nl < 2*iterations; nl++) {
+        im1 = LEN_1D-1;
+        for (int i = 0; i < LEN_1D; i++) {
+            a[i] = (b[i] + b[im1]) * (real_t).5;
+            im1 = i;
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.9
+
+real_t s292(struct args_t * func_args)
+{
+
+//    loop peeling
+//    wrap around variable, 2 levels
+//    similar to S291
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    int im1, im2;
+    for (int nl = 0; nl < iterations; nl++) {
+        im1 = LEN_1D-1;
+        im2 = LEN_1D-2;
+        for (int i = 0; i < LEN_1D; i++) {
+            a[i] = (b[i] + b[im1] + b[im2]) * (real_t).333;
+            im2 = im1;
+            im1 = i;
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.9
+
+real_t s293(struct args_t * func_args)
+{
+
+//    loop peeling
+//    a(i)=a(0) with actual dependence cycle, loop is vectorizable
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 4*iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            a[i] = a[0];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.10
+
+real_t s2101(struct args_t * func_args)
+{
+
+//    diagonals
+//    main diagonal calculation
+//    jump in data access
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 10*iterations; nl++) {
+        for (int i = 0; i < LEN_2D; i++) {
+            aa[i][i] += bb[i][i] * cc[i][i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.12
+
+real_t s2102(struct args_t * func_args)
+{
+
+//    diagonals
+//    identity matrix, best results vectorize both inner and outer loops
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 100*(iterations/LEN_2D); nl++) {
+        for (int i = 0; i < LEN_2D; i++) {
+            for (int j = 0; j < LEN_2D; j++) {
+                aa[j][i] = (real_t)0.;
+            }
+            aa[i][i] = (real_t)1.;
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %2.11
+
+real_t s2111(struct args_t * func_args)
+{
+
+//    wavefronts, it will make jump in data access
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 100*(iterations/(LEN_2D)); nl++) {
+        for (int j = 1; j < LEN_2D; j++) {
+            for (int i = 1; i < LEN_2D; i++) {
+                aa[j][i] = (aa[j][i-1] + aa[j-1][i])/1.9;
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// **********************************************************
+//                                *
+//            IDIOM RECOGNITION            *
+//                                *
+// **********************************************************
+
+// %3.1
+
+real_t s311(struct args_t * func_args)
+{
+
+//    reductions
+//    sum reduction
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    real_t sum;
+    for (int nl = 0; nl < iterations*10; nl++) {
+        sum = (real_t)0.;
+        for (int i = 0; i < LEN_1D; i++) {
+            sum += a[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, sum);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+real_t test(real_t* A){
+  real_t s = (real_t)0.0;
+  for (int i = 0; i < 4; i++)
+    s += A[i];
+  return s;
+}
+
+real_t s31111(struct args_t * func_args)
+{
+
+//    reductions
+//    sum reduction
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    real_t sum;
+    for (int nl = 0; nl < 2000*iterations; nl++) {
+        sum = (real_t)0.;
+        sum += test(a);
+        sum += test(&a[4]);
+        sum += test(&a[8]);
+        sum += test(&a[12]);
+        sum += test(&a[16]);
+        sum += test(&a[20]);
+        sum += test(&a[24]);
+        sum += test(&a[28]);
+        dummy(a, b, c, d, e, aa, bb, cc, sum);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %3.1
+
+real_t s312(struct args_t * func_args)
+{
+
+//    reductions
+//    product reduction
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    real_t prod;
+    for (int nl = 0; nl < 10*iterations; nl++) {
+        prod = (real_t)1.;
+        for (int i = 0; i < LEN_1D; i++) {
+            prod *= a[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, prod);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return prod;
+}
+
+// %3.1
+real_t s313(struct args_t * func_args)
+{
+
+//    reductions
+//    dot product
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    real_t dot;
+    for (int nl = 0; nl < iterations*5; nl++) {
+        dot = (real_t)0.;
+        for (int i = 0; i < LEN_1D; i++) {
+            dot += a[i] * b[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, dot);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return dot;
+}
+
+// %3.1
+
+real_t s314(struct args_t * func_args)
+{
+
+//    reductions
+//    if to max reduction
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    real_t x;
+    for (int nl = 0; nl < iterations*5; nl++) {
+        x = a[0];
+        for (int i = 0; i < LEN_1D; i++) {
+            if (a[i] > x) {
+                x = a[i];
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, x);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return x;
+}
+
+// %3.1
+
+real_t s315(struct args_t * func_args)
+{
+
+//    reductions
+//    if to max with index reductio 1 dimension
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int i = 0; i < LEN_1D; i++)
+        a[i] = (i * 7) % LEN_1D;
+
+    real_t x, chksum;
+    int index;
+    for (int nl = 0; nl < iterations; nl++) {
+        x = a[0];
+        index = 0;
+        for (int i = 0; i < LEN_1D; ++i) {
+            if (a[i] > x) {
+                x = a[i];
+                index = i;
+            }
+        }
+        chksum = x + (real_t) index;
+        dummy(a, b, c, d, e, aa, bb, cc, chksum);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return index + x + 1;
+}
+
+// %3.1
+
+real_t s316(struct args_t * func_args)
+{
+
+//    reductions
+//    if to min reduction
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    real_t x;
+    for (int nl = 0; nl < iterations*5; nl++) {
+        x = a[0];
+        for (int i = 1; i < LEN_1D; ++i) {
+            if (a[i] < x) {
+                x = a[i];
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, x);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return x;
+}
+// %3.1
+
+real_t s317(struct args_t * func_args)
+{
+
+//    reductions
+//    product reductio vectorize with
+//    1. scalar expansion of factor, and product reduction
+//    2. closed form solution: q = factor**n
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    real_t q;
+    for (int nl = 0; nl < 5*iterations; nl++) {
+        q = (real_t)1.;
+        for (int i = 0; i < LEN_1D/2; i++) {
+            q *= (real_t).99;
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, q);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return q;
+}
+
+// %3.1
+
+//int s318( int inc)
+real_t s318(struct args_t * func_args)
+{
+
+//    reductions
+//    isamax, max absolute value, increments not equal to 1
+
+    int inc = *(int*)func_args->arg_info;
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    int k, index;
+    real_t max, chksum;
+    for (int nl = 0; nl < iterations/2; nl++) {
+        k = 0;
+        index = 0;
+        max = ABS(a[0]);
+        k += inc;
+        for (int i = 1; i < LEN_1D; i++) {
+            if (ABS(a[k]) <= max) {
+                goto L5;
+            }
+            index = i;
+            max = ABS(a[k]);
+L5:
+            k += inc;
+        }
+        chksum = max + (real_t) index;
+        dummy(a, b, c, d, e, aa, bb, cc, chksum);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return max + index + 1;
+}
+
+// %3.1
+
+real_t s319(struct args_t * func_args)
+{
+
+//    reductions
+//    coupled reductions
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    real_t sum;
+    for (int nl = 0; nl < 2*iterations; nl++) {
+        sum = 0.;
+        for (int i = 0; i < LEN_1D; i++) {
+            a[i] = c[i] + d[i];
+            sum += a[i];
+            b[i] = c[i] + e[i];
+            sum += b[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, sum);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return sum;
+}
+
+// %3.1
+
+real_t s3110(struct args_t * func_args)
+{
+
+//    reductions
+//    if to max with index reductio 2 dimensions
+//    similar to S315
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    int xindex, yindex;
+    real_t max, chksum;
+    for (int nl = 0; nl < 100*(iterations/(LEN_2D)); nl++) {
+        max = aa[(0)][0];
+        xindex = 0;
+        yindex = 0;
+        for (int i = 0; i < LEN_2D; i++) {
+            for (int j = 0; j < LEN_2D; j++) {
+                if (aa[i][j] > max) {
+                    max = aa[i][j];
+                    xindex = i;
+                    yindex = j;
+                }
+            }
+        }
+        chksum = max + (real_t) xindex + (real_t) yindex;
+        dummy(a, b, c, d, e, aa, bb, cc, chksum);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return max + xindex+1 + yindex+1;
+}
+
+real_t s13110(struct args_t * func_args)
+{
+
+//    reductions
+//    if to max with index reductio 2 dimensions
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    int xindex, yindex;
+    real_t max, chksum;
+    for (int nl = 0; nl < 100*(iterations/(LEN_2D)); nl++) {
+        max = aa[(0)][0];
+        xindex = 0;
+        yindex = 0;
+        for (int i = 0; i < LEN_2D; i++) {
+            for (int j = 0; j < LEN_2D; j++) {
+                if (aa[i][j] > max) {
+                    max = aa[i][j];
+                    xindex = i;
+                    yindex = j;
+                }
+            }
+        }
+        chksum = max + (real_t) xindex + (real_t) yindex;
+        dummy(a, b, c, d, e, aa, bb, cc, chksum);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return max + xindex+1 + yindex+1;
+}
+
+// %3.1
+
+real_t s3111(struct args_t * func_args)
+{
+
+//    reductions
+//    conditional sum reduction
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    real_t sum;
+    for (int nl = 0; nl < iterations/2; nl++) {
+        sum = 0.;
+        for (int i = 0; i < LEN_1D; i++) {
+            if (a[i] > (real_t)0.) {
+                sum += a[i];
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, sum);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return sum;
+}
+
+// %3.1
+
+real_t s3112(struct args_t * func_args)
+{
+
+//    reductions
+//    sum reduction saving running sums
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    real_t sum;
+    for (int nl = 0; nl < iterations; nl++) {
+        sum = (real_t)0.0;
+        for (int i = 0; i < LEN_1D; i++) {
+            sum += a[i];
+            b[i] = sum;
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, sum);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return sum;
+}
+
+// %3.1
+
+real_t s3113(struct args_t * func_args)
+{
+
+//    reductions
+//    maximum of absolute value
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    real_t max;
+    for (int nl = 0; nl < iterations*4; nl++) {
+        max = ABS(a[0]);
+        for (int i = 0; i < LEN_1D; i++) {
+            if ((ABS(a[i])) > max) {
+                max = ABS(a[i]);
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, max);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return max;
+}
+
+// %3.2
+
+real_t s321(struct args_t * func_args)
+{
+
+//    recurrences
+//    first order linear recurrence
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = 1; i < LEN_1D; i++) {
+            a[i] += a[i-1] * b[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %3.2
+
+real_t s322(struct args_t * func_args)
+{
+
+//    recurrences
+//    second order linear recurrence
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations/2; nl++) {
+        for (int i = 2; i < LEN_1D; i++) {
+            a[i] = a[i] + a[i - 1] * b[i] + a[i - 2] * c[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %3.2
+
+real_t s323(struct args_t * func_args)
+{
+
+//    recurrences
+//    coupled recurrence
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations/2; nl++) {
+        for (int i = 1; i < LEN_1D; i++) {
+            a[i] = b[i-1] + c[i] * d[i];
+            b[i] = a[i] + c[i] * e[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %3.3
+
+real_t s331(struct args_t * func_args)
+{
+
+//    search loops
+//    if to last-1
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    int j;
+    real_t chksum;
+    for (int nl = 0; nl < iterations; nl++) {
+        j = -1;
+        for (int i = 0; i < LEN_1D; i++) {
+            if (a[i] < (real_t)0.) {
+                j = i;
+            }
+        }
+        chksum = (real_t) j;
+        dummy(a, b, c, d, e, aa, bb, cc, chksum);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return j+1;
+}
+
+// %3.3
+//int s332( real_t t)
+real_t s332(struct args_t * func_args)
+{
+
+//    search loops
+//    first value greater than threshold
+
+    int t = *(int*)func_args->arg_info;
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    int index;
+    real_t value;
+    real_t chksum;
+    for (int nl = 0; nl < iterations; nl++) {
+        index = -2;
+        value = -1.;
+        for (int i = 0; i < LEN_1D; i++) {
+            if (a[i] > t) {
+                index = i;
+                value = a[i];
+                goto L20;
+            }
+        }
+L20:
+        chksum = value + (real_t) index;
+        dummy(a, b, c, d, e, aa, bb, cc, chksum);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return value;
+}
+
+// %3.4
+
+real_t s341(struct args_t * func_args)
+{
+
+//    packing
+//    pack positive values
+//    not vectorizable, value of j in unknown at each iteration
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    int j;
+    for (int nl = 0; nl < iterations; nl++) {
+        j = -1;
+        for (int i = 0; i < LEN_1D; i++) {
+            if (b[i] > (real_t)0.) {
+                j++;
+                a[j] = b[i];
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %3.4
+
+real_t s342(struct args_t * func_args)
+{
+
+//    packing
+//    unpacking
+//    not vectorizable, value of j in unknown at each iteration
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    int j = 0;
+    for (int nl = 0; nl < iterations; nl++) {
+        j = -1;
+        for (int i = 0; i < LEN_1D; i++) {
+            if (a[i] > (real_t)0.) {
+                j++;
+                a[i] = b[j];
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %3.4
+
+real_t s343(struct args_t * func_args)
+{
+
+//    packing
+//    pack 2-d array into one dimension
+//    not vectorizable, value of k in unknown at each iteration
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    int k;
+    for (int nl = 0; nl < 10*(iterations/LEN_2D); nl++) {
+        k = -1;
+        for (int i = 0; i < LEN_2D; i++) {
+            for (int j = 0; j < LEN_2D; j++) {
+                if (bb[j][i] > (real_t)0.) {
+                    k++;
+                    flat_2d_array[k] = aa[j][i];
+                }
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %3.5
+
+real_t s351(struct args_t * func_args)
+{
+
+//    loop rerolling
+//    unrolled saxpy
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    real_t alpha = c[0];
+    for (int nl = 0; nl < 8*iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i += 5) {
+            a[i] += alpha * b[i];
+            a[i + 1] += alpha * b[i + 1];
+            a[i + 2] += alpha * b[i + 2];
+            a[i + 3] += alpha * b[i + 3];
+            a[i + 4] += alpha * b[i + 4];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+real_t s1351(struct args_t * func_args)
+{
+
+//    induction pointer recognition
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 8*iterations; nl++) {
+        real_t* __restrict__ A = a;
+        real_t* __restrict__ B = b;
+        real_t* __restrict__ C = c;
+        for (int i = 0; i < LEN_1D; i++) {
+            *A = *B+*C;
+            A++;
+            B++;
+            C++;
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %3.5
+
+real_t s352(struct args_t * func_args)
+{
+
+//    loop rerolling
+//    unrolled dot product
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    real_t dot;
+    for (int nl = 0; nl < 8*iterations; nl++) {
+        dot = (real_t)0.;
+        for (int i = 0; i < LEN_1D; i += 5) {
+            dot = dot + a[i] * b[i] + a[i + 1] * b[i + 1] + a[i + 2]
+                * b[i + 2] + a[i + 3] * b[i + 3] + a[i + 4] * b[i + 4];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, dot);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return dot;
+}
+
+// %3.5
+
+//int s353(int* __restrict__ ip)
+real_t s353(struct args_t * func_args)
+{
+
+//    loop rerolling
+//    unrolled sparse saxpy
+//    gather is required
+
+    int * __restrict__ ip = func_args->arg_info;
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    real_t alpha = c[0];
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i += 5) {
+            a[i] += alpha * b[ip[i]];
+            a[i + 1] += alpha * b[ip[i + 1]];
+            a[i + 2] += alpha * b[ip[i + 2]];
+            a[i + 3] += alpha * b[ip[i + 3]];
+            a[i + 4] += alpha * b[ip[i + 4]];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// **********************************************************
+//                                *
+//             LANGUAGE COMPLETENESS            *
+//                                *
+// **********************************************************
+
+// %4.1
+// %4.2
+
+real_t s421(struct args_t * func_args)
+{
+
+//    storage classes and equivalencing
+//    equivalence- no overlap
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    xx = flat_2d_array;
+
+    for (int nl = 0; nl < 4*iterations; nl++) {
+        yy = xx;
+        for (int i = 0; i < LEN_1D - 1; i++) {
+            xx[i] = yy[i+1] + a[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 1.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+real_t s1421(struct args_t * func_args)
+{
+
+//    storage classes and equivalencing
+//    equivalence- no overlap
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    xx = &b[LEN_1D/2];
+
+    for (int nl = 0; nl < 8*iterations; nl++) {
+        for (int i = 0; i < LEN_1D/2; i++) {
+            b[i] = xx[i] + a[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 1.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %4.2
+
+real_t s422(struct args_t * func_args)
+{
+
+//    storage classes and equivalencing
+//    common and equivalence statement
+//    anti-dependence, threshold of 4
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    xx = flat_2d_array + 4;
+
+    for (int nl = 0; nl < 8*iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            xx[i] = flat_2d_array[i + 8] + a[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %4.2
+
+real_t s423(struct args_t * func_args)
+{
+
+//    storage classes and equivalencing
+//    common and equivalenced variables - with anti-dependence
+
+    // do this again here
+    int vl = 64;
+    xx = flat_2d_array + vl;
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 4*iterations; nl++) {
+        for (int i = 0; i < LEN_1D - 1; i++) {
+            flat_2d_array[i+1] = xx[i] + a[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 1.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %4.2
+
+real_t s424(struct args_t * func_args)
+{
+
+//    storage classes and equivalencing
+//    common and equivalenced variables - overlap
+//    vectorizeable in strips of 64 or less
+
+    // do this again here
+    int vl = 63;
+    xx = flat_2d_array + vl;
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 4*iterations; nl++) {
+        for (int i = 0; i < LEN_1D - 1; i++) {
+            xx[i+1] = flat_2d_array[i] + a[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 1.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %4.3
+
+real_t s431(struct args_t * func_args)
+{
+
+//    parameters
+//    parameter statement
+
+    int k1=1;
+    int k2=2;
+    int k=2*k1-k2;
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations*10; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            a[i] = a[i+k] + b[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %4.4
+
+real_t s441(struct args_t * func_args)
+{
+
+//    non-logical if's
+//    arithmetic if
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            if (d[i] < (real_t)0.) {
+                a[i] += b[i] * c[i];
+            } else if (d[i] == (real_t)0.) {
+                a[i] += b[i] * b[i];
+            } else {
+                a[i] += c[i] * c[i];
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %4.4
+
+real_t s442(struct args_t * func_args)
+{
+
+//    non-logical if's
+//    computed goto
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations/2; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            switch (indx[i]) {
+                case 1:  goto L15;
+                case 2:  goto L20;
+                case 3:  goto L30;
+                case 4:  goto L40;
+            }
+L15:
+            a[i] += b[i] * b[i];
+            goto L50;
+L20:
+            a[i] += c[i] * c[i];
+            goto L50;
+L30:
+            a[i] += d[i] * d[i];
+            goto L50;
+L40:
+            a[i] += e[i] * e[i];
+L50:
+            ;
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %4.4
+
+real_t s443(struct args_t * func_args)
+{
+
+//    non-logical if's
+//    arithmetic if
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 2*iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            if (d[i] <= (real_t)0.) {
+                goto L20;
+            } else {
+                goto L30;
+            }
+L20:
+            a[i] += b[i] * c[i];
+            goto L50;
+L30:
+            a[i] += b[i] * b[i];
+L50:
+            ;
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %4.5
+
+real_t s451(struct args_t * func_args)
+{
+
+//    intrinsic functions
+//    intrinsics
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations/5; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            a[i] = sinf(b[i]) + cosf(c[i]);
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %4.5
+
+real_t s452(struct args_t * func_args)
+{
+
+//    intrinsic functions
+//    seq function
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 4*iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            a[i] = b[i] + c[i] * (real_t) (i+1);
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %4.5
+
+real_t s453(struct args_t * func_args)
+{
+
+//    induction varibale recognition
+
+    real_t s;
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations*2; nl++) {
+        s = 0.;
+        for (int i = 0; i < LEN_1D; i++) {
+            s += (real_t)2.;
+            a[i] = s * b[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %4.7
+
+int s471s(void)
+{
+// --  dummy subroutine call made in s471
+    return 0;
+}
+
+real_t s471(struct args_t * func_args){
+
+//    call statements
+
+    int m = LEN_1D;
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations/2; nl++) {
+        for (int i = 0; i < m; i++) {
+            x[i] = b[i] + d[i] * d[i];
+            s471s();
+            b[i] = c[i] + d[i] * e[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %4.8
+
+real_t s481(struct args_t * func_args)
+{
+
+//    non-local goto's
+//    stop statement
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            if (d[i] < (real_t)0.) {
+                exit (0);
+            }
+            a[i] += b[i] * c[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %4.8
+
+// %4.8
+real_t s482(struct args_t * func_args)
+{
+
+//    non-local goto's
+//    other loop exit with code before exit
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            a[i] += b[i] * c[i];
+            if (c[i] > b[i]) break;
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %4.9
+
+//int s491(int* __restrict__ ip)
+real_t s491(struct args_t * func_args)
+{
+
+//    vector semantics
+//    indirect addressing on lhs, store in sequence
+//    scatter is required
+
+    int * __restrict__ ip = func_args->arg_info;
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            a[ip[i]] = b[i] + c[i] * d[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %4.11
+
+//int s4112(int* __restrict__ ip, real_t s)
+real_t s4112(struct args_t * func_args)
+{
+
+//    indirect addressing
+//    sparse saxpy
+//    gather is required
+
+    struct{int * __restrict__ a;real_t b;} * x = func_args->arg_info;
+    int * __restrict__ ip = x->a;
+    real_t s = x->b;
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            a[i] += b[ip[i]] * s;
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %4.11
+
+//int s4113(int* __restrict__ ip)
+real_t s4113(struct args_t * func_args)
+{
+
+//    indirect addressing
+//    indirect addressing on rhs and lhs
+//    gather and scatter is required
+
+    int * __restrict__ ip = func_args->arg_info;
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            a[ip[i]] = b[ip[i]] + c[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %4.11
+
+//int s4114(int* ip, int n1)
+real_t s4114(struct args_t * func_args)
+{
+
+//    indirect addressing
+//    mix indirect addressing with variable lower and upper bounds
+//    gather is required
+
+    struct{int * __restrict__ a;int b;} * x = func_args->arg_info;
+    int * __restrict__ ip = x->a;
+    int n1 = x->b;
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    int k;
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = n1-1; i < LEN_1D; i++) {
+            k = ip[i];
+            a[i] = b[i] + c[LEN_1D-k+1-2] * d[i];
+            k += 5;
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %4.11
+
+//int s4115(int* __restrict__ ip)
+real_t s4115(struct args_t * func_args)
+{
+
+//    indirect addressing
+//    sparse dot product
+//    gather is required
+
+    int * __restrict__ ip = func_args->arg_info;
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    real_t sum;
+    for (int nl = 0; nl < iterations; nl++) {
+        sum = 0.;
+        for (int i = 0; i < LEN_1D; i++) {
+            sum += a[i] * b[ip[i]];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return sum;
+}
+
+// %4.11
+
+//int s4116(int* __restrict__ ip, int j, int inc)
+real_t s4116(struct args_t * func_args)
+{
+
+//    indirect addressing
+//    more complicated sparse sdot
+//    gather is required
+
+    struct{int * __restrict__ a;int b;int c;} * x = func_args->arg_info;
+    int * __restrict__ ip = x->a;
+    int j = x->b;
+    int inc = x->c;
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    real_t sum;
+    int off;
+    for (int nl = 0; nl < 100*iterations; nl++) {
+        sum = 0.;
+        for (int i = 0; i < LEN_2D-1; i++) {
+            off = inc + i;
+            sum += a[off] * aa[j-1][ip[i]];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return sum;
+}
+
+// %4.11
+
+real_t s4117(struct args_t * func_args)
+{
+
+//    indirect addressing
+//    seq function
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            a[i] = b[i] + c[i/2] * d[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %4.12
+
+real_t f(real_t a, real_t b){
+    return a*b;
+}
+
+real_t s4121(struct args_t * func_args)
+{
+
+//    statement functions
+//    elementwise multiplication
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            a[i] += f(b[i],c[i]);
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %5.1
+
+real_t va(struct args_t * func_args)
+{
+
+//    control loops
+//    vector assignment
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations*10; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            a[i] = b[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %5.1
+
+//int vag( int* __restrict__ ip)
+real_t vag(struct args_t * func_args)
+{
+
+//    control loops
+//    vector assignment, gather
+//    gather is required
+
+    int * __restrict__ ip = func_args->arg_info;
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 2*iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            a[i] = b[ip[i]];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %5.1
+
+//int vas( int* __restrict__ ip)
+real_t vas(struct args_t * func_args)
+{
+
+//    control loops
+//    vector assignment, scatter
+//    scatter is required
+
+    int * __restrict__ ip = func_args->arg_info;
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 2*iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            a[ip[i]] = b[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %5.1
+
+real_t vif(struct args_t * func_args)
+{
+
+//    control loops
+//    vector if
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            if (b[i] > (real_t)0.) {
+                a[i] = b[i];
+            }
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %5.1
+
+real_t vpv(struct args_t * func_args)
+{
+
+//    control loops
+//    vector plus vector
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations*10; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            a[i] += b[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %5.1
+
+real_t vtv(struct args_t * func_args)
+{
+
+//    control loops
+//    vector times vector
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations*10; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            a[i] *= b[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %5.1
+
+real_t vpvtv(struct args_t * func_args)
+{
+
+//    control loops
+//    vector plus vector times vector
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 4*iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            a[i] += b[i] * c[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %5.1
+
+//real_t vpvts( real_t s)
+real_t vpvts(struct args_t * func_args)
+{
+
+//    control loops
+//    vector plus vector times scalar
+
+    real_t s = *(int*)func_args->arg_info;
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            a[i] += b[i] * s;
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %5.1
+
+real_t vpvpv(struct args_t * func_args)
+{
+
+//    control loops
+//    vector plus vector plus vector
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 4*iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            a[i] += b[i] + c[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %5.1
+
+real_t vtvtv(struct args_t * func_args)
+{
+
+//    control loops
+//    vector times vector times vector
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    for (int nl = 0; nl < 4*iterations; nl++) {
+        for (int i = 0; i < LEN_1D; i++) {
+            a[i] = a[i] * b[i] * c[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+// %5.1
+
+real_t vsumr(struct args_t * func_args)
+{
+
+//    control loops
+//    vector sum reduction
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    real_t sum;
+    for (int nl = 0; nl < iterations*10; nl++) {
+        sum = 0.;
+        for (int i = 0; i < LEN_1D; i++) {
+            sum += a[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, sum);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return sum;
+}
+
+// %5.1
+
+real_t vdotr(struct args_t * func_args)
+{
+
+//    control loops
+//    vector dot product reduction
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    real_t dot;
+    for (int nl = 0; nl < iterations*10; nl++) {
+        dot = 0.;
+        for (int i = 0; i < LEN_1D; i++) {
+            dot += a[i] * b[i];
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, dot);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return dot;
+}
+
+// %5.1
+
+real_t vbor(struct args_t * func_args)
+{
+
+//    control loops
+//    basic operations rates, isolate arithmetic from memory traffic
+//    all combinations of three, 59 flops for 6 loads and 1 store.
+
+    initialise_arrays(__func__);
+    gettimeofday(&func_args->t1, NULL);
+
+    real_t a1, b1, c1, d1, e1, f1;
+    for (int nl = 0; nl < iterations*10; nl++) {
+        for (int i = 0; i < LEN_2D; i++) {
+            a1 = a[i];
+            b1 = b[i];
+            c1 = c[i];
+            d1 = d[i];
+            e1 = e[i];
+            f1 = aa[0][i];
+            a1 = a1 * b1 * c1 + a1 * b1 * d1 + a1 * b1 * e1 + a1 * b1 * f1 +
+                a1 * c1 * d1 + a1 * c1 * e1 + a1 * c1 * f1 + a1 * d1 * e1
+                + a1 * d1 * f1 + a1 * e1 * f1;
+            b1 = b1 * c1 * d1 + b1 * c1 * e1 + b1 * c1 * f1 + b1 * d1 * e1 +
+                b1 * d1 * f1 + b1 * e1 * f1;
+            c1 = c1 * d1 * e1 + c1 * d1 * f1 + c1 * e1 * f1;
+            d1 = d1 * e1 * f1;
+            x[i] = a1 * b1 * c1 * d1;
+        }
+        dummy(a, b, c, d, e, aa, bb, cc, 0.);
+    }
+
+    gettimeofday(&func_args->t2, NULL);
+    return calc_checksum(__func__);
+}
+
+typedef real_t(*test_function_t)(struct args_t *);
+
+void time_function(test_function_t vector_func, void * arg_info)
+{
+    struct args_t func_args = {.arg_info=arg_info};
+
+    double result = vector_func(&func_args);
+
+    double tic=func_args.t1.tv_sec+(func_args.t1.tv_usec/1000000.0);
+    double toc=func_args.t2.tv_sec+(func_args.t2.tv_usec/1000000.0);
+
+    double taken = toc-tic;
+
+    printf("%10.3f\t%f\n", taken, result);
+}
+
+int main(int argc, char ** argv){
+    INIT();
+    int n1 = 1;
+    int n3 = 1;
+    int* ip;
+    real_t s1,s2;
+    init(&ip, &s1, &s2);
+    printf("Loop \tTime(sec) \tChecksum\n");
+
+    time_function(&s000, NULL);
+    time_function(&s111, NULL);
+    time_function(&s1111, NULL);
+    time_function(&s112, NULL);
+    time_function(&s1112, NULL);
+    time_function(&s113, NULL);
+    time_function(&s1113, NULL);
+    time_function(&s114, NULL);
+    time_function(&s115, NULL);
+    time_function(&s1115, NULL);
+    time_function(&s116, NULL);
+    time_function(&s118, NULL);
+    time_function(&s119, NULL);
+    time_function(&s1119, NULL);
+    time_function(&s121, NULL);
+    time_function(&s122, &(struct{int a;int b;}){n1, n3});
+    time_function(&s123, NULL);
+    time_function(&s124, NULL);
+    time_function(&s125, NULL);
+    time_function(&s126, NULL);
+    time_function(&s127, NULL);
+    time_function(&s128, NULL);
+    time_function(&s131, NULL);
+    time_function(&s132, NULL);
+    time_function(&s141, NULL);
+    time_function(&s151, NULL);
+    time_function(&s152, NULL);
+    time_function(&s161, NULL);
+    time_function(&s1161, NULL);
+    time_function(&s162, &n1);
+    time_function(&s171, &n1);
+    time_function(&s172, &(struct{int a;int b;}){n1, n3});
+    time_function(&s173, NULL);
+    time_function(&s174, &(struct{int a;}){LEN_1D/2});
+    time_function(&s175, &n1);
+    time_function(&s176, NULL);
+    time_function(&s211, NULL);
+    time_function(&s212, NULL);
+    time_function(&s1213, NULL);
+    time_function(&s221, NULL);
+    time_function(&s1221, NULL);
+    time_function(&s222, NULL);
+    time_function(&s231, NULL);
+    time_function(&s232, NULL);
+    time_function(&s1232, NULL);
+    time_function(&s233, NULL);
+    time_function(&s2233, NULL);
+    time_function(&s235, NULL);
+    time_function(&s241, NULL);
+    time_function(&s242, &(struct{real_t a;real_t b;}){s1, s2});
+    time_function(&s243, NULL);
+    time_function(&s244, NULL);
+    time_function(&s1244, NULL);
+    time_function(&s2244, NULL);
+    time_function(&s251, NULL);
+    time_function(&s1251, NULL);
+    time_function(&s2251, NULL);
+    time_function(&s3251, NULL);
+    time_function(&s252, NULL);
+    time_function(&s253, NULL);
+    time_function(&s254, NULL);
+    time_function(&s255, NULL);
+    time_function(&s256, NULL);
+    time_function(&s257, NULL);
+    time_function(&s258, NULL);
+    time_function(&s261, NULL);
+    time_function(&s271, NULL);
+    time_function(&s272, &s1);
+    time_function(&s273, NULL);
+    time_function(&s274, NULL);
+    time_function(&s275, NULL);
+    time_function(&s2275, NULL);
+    time_function(&s276, NULL);
+    time_function(&s277, NULL);
+    time_function(&s278, NULL);
+    time_function(&s279, NULL);
+    time_function(&s1279, NULL);
+    time_function(&s2710, &s1);
+    time_function(&s2711, NULL);
+    time_function(&s2712, NULL);
+    time_function(&s281, NULL);
+    time_function(&s1281, NULL);
+    time_function(&s291, NULL);
+    time_function(&s292, NULL);
+    time_function(&s293, NULL);
+    time_function(&s2101, NULL);
+    time_function(&s2102, NULL);
+    time_function(&s2111, NULL);
+    time_function(&s311, NULL);
+    time_function(&s31111, NULL);
+    time_function(&s312, NULL);
+    time_function(&s313, NULL);
+    time_function(&s314, NULL);
+    time_function(&s315, NULL);
+    time_function(&s316, NULL);
+    time_function(&s317, NULL);
+    time_function(&s318, &n1);
+    time_function(&s319, NULL);
+    time_function(&s3110, NULL);
+    time_function(&s13110, NULL);
+    time_function(&s3111, NULL);
+    time_function(&s3112, NULL);
+    time_function(&s3113, NULL);
+    time_function(&s321, NULL);
+    time_function(&s322, NULL);
+    time_function(&s323, NULL);
+    time_function(&s331, NULL);
+    time_function(&s332, &s1);
+    time_function(&s341, NULL);
+    time_function(&s342, NULL);
+    time_function(&s343, NULL);
+    time_function(&s351, NULL);
+    time_function(&s1351, NULL);
+    time_function(&s352, NULL);
+    time_function(&s353, ip);
+    time_function(&s421, NULL);
+    time_function(&s1421, NULL);
+    time_function(&s422, NULL);
+    time_function(&s423, NULL);
+    time_function(&s424, NULL);
+    time_function(&s431, NULL);
+    time_function(&s441, NULL);
+    time_function(&s442, NULL);
+    time_function(&s443, NULL);
+    time_function(&s451, NULL);
+    time_function(&s452, NULL);
+    time_function(&s453, NULL);
+    time_function(&s471, NULL);
+    time_function(&s481, NULL);
+    time_function(&s482, NULL);
+    time_function(&s491, ip);
+    time_function(&s4112, &(struct{int*a;real_t b;}){ip, s1});
+    time_function(&s4113, ip);
+    time_function(&s4114, &(struct{int*a;int b;}){ip, n1});
+    time_function(&s4115, ip);
+    time_function(&s4116, &(struct{int * a; int b; int c;}){ip, LEN_2D/2, n1});
+    time_function(&s4117, NULL);
+    time_function(&s4121, NULL);
+    time_function(&va, NULL);
+    time_function(&vag, ip);
+    time_function(&vas, ip);
+    time_function(&vif, NULL);
+    time_function(&vpv, NULL);
+    time_function(&vtv, NULL);
+    time_function(&vpvtv, NULL);
+    time_function(&vpvts, &s1);
+    time_function(&vpvpv, NULL);
+    time_function(&vtvtv, NULL);
+    time_function(&vsumr, NULL);
+    time_function(&vdotr, NULL);
+    time_function(&vbor, NULL);
+
+    return 0;
+}

--- a/apps/tsvc/src/undefined_lib.c
+++ b/apps/tsvc/src/undefined_lib.c
@@ -77,14 +77,3 @@ float cosf(float x) {
     }
     return result;
 }
-
-
-int exit(int a){
-    if(a==0){
-        printf("Success! Exit with 0.\n");
-        assert(0);
-    } else{
-        printf("Failed! Exit with %d.\n",a);
-        assert(0);
-    }
-}

--- a/apps/tsvc/src/undefined_lib.c
+++ b/apps/tsvc/src/undefined_lib.c
@@ -1,0 +1,90 @@
+
+#include "undefined_lib.h"
+
+void *memalign(size_t alignment, size_t size) {
+    if (alignment == 0 || (alignment & (alignment - 1)) != 0) {
+        return NULL;
+    }
+    size_t total_size = size + alignment + sizeof(void *);
+
+    void *raw_memory = malloc(total_size);
+    uintptr_t raw_address = (uintptr_t)raw_memory;
+    uintptr_t aligned_address = (raw_address + sizeof(void *) + alignment - 1) & ~(alignment - 1);
+    void **aligned_ptr = (void **)aligned_address;
+
+    aligned_ptr[-1] = raw_memory;
+
+    return (void *)aligned_ptr;
+}
+
+
+int gettimeofday(struct timeval * rtc, void * null) {
+    rtc->tv_usec = uptime();
+    return 0;
+}
+
+
+int fprintf(void *file, const char *format, ...) {
+    va_list args;
+    va_start(args, format);
+    int result = printf(format, args);
+    return result;
+}
+
+
+float fabsf(float x) {
+    return x < 0 ? -x : x;
+}
+
+
+double factorial(int n) {
+    double result = 1.0;
+    for (int i = 1; i <= n; i++) {
+        result *= i;
+    }
+    return result;
+}
+
+double power(double x, int n) {
+    double result = 1.0;
+    for (int i = 0; i < n; i++) {
+        result *= x;
+    }
+    return result;
+}
+
+double toRadians(double degrees) {
+    return degrees * (PI / 180.0);
+}
+
+float sinf(float x) {
+    x = toRadians(x);
+    float result = 0.0;
+    int terms = 10;
+    for (int n = 0; n < terms; n++) {
+        int sign = (n % 2 == 0) ? 1 : -1;
+        result += sign * (power(x, 2 * n + 1) / factorial(2 * n + 1));
+    }
+    return result;
+}
+float cosf(float x) {
+    x = toRadians(x);
+    float result = 0.0;
+    int terms = 10;
+    for (int n = 0; n < terms; n++) {
+        int sign = (n % 2 == 0) ? 1 : -1;
+        result += sign * (power(x, 2 * n) / factorial(2 * n));
+    }
+    return result;
+}
+
+
+int exit(int a){
+    if(a==0){
+        printf("Success! Exit with 0.\n");
+        assert(0);
+    } else{
+        printf("Failed! Exit with %d.\n",a);
+        assert(0);
+    }
+}


### PR DESCRIPTION
To perform the test, we made the following modifications to the original program:

1. We modified the makefile to enable compilation in the AM environment.

2. We reduced the value of the iterations variable in common.h (from 100,000 to 100) to shorten the runtime.

3. We added the library files required for the test (undefined_lib.h, undefined_lib.c), specifically the sinf and cosf functions needed for test s451. This may lead to performance and result differences compared to running on a Linux system.

The tests show that the benchmark can run successfully on the riscv64-xs architecture in NEMU.