### PR TITLE
fix(build): replace csr name `sptbr` with `satp`

### DIFF
--- a/tests/aliastest/src/alias.S
+++ b/tests/aliastest/src/alias.S
@@ -50,7 +50,7 @@ do_alias_init:
   la a1, page_table_1
   srl a1, a1, RISCV_PGSHIFT
   or a1, a1, a0
-  csrw sptbr, a1
+  csrw satp, a1
   sfence.vma
 
   # Enter supervisor mode and make sure correct page is accessed

--- a/tests/aliastest/src/alias_jit.S
+++ b/tests/aliastest/src/alias_jit.S
@@ -50,7 +50,7 @@ do_alias_jit_init:
   la a1, page_table_1
   srl a1, a1, RISCV_PGSHIFT
   or a1, a1, a0
-  csrw sptbr, a1
+  csrw satp, a1
   sfence.vma
 
   # Write code to code_page

--- a/tests/memscantest/src/main.c
+++ b/tests/memscantest/src/main.c
@@ -173,7 +173,7 @@ static void init_pt()
 #else
   uintptr_t vm_choice = SATP_MODE_SV32;
 #endif
-  write_csr(sptbr, ((uintptr_t)l1pt >> RISCV_PGSHIFT) |
+  write_csr(satp, ((uintptr_t)l1pt >> RISCV_PGSHIFT) |
                    (vm_choice * (SATP_MODE & ~(SATP_MODE<<1))));
 }
 

--- a/tests/softmdutest/main.c
+++ b/tests/softmdutest/main.c
@@ -1,5 +1,6 @@
 #include <am.h>
 #include <klib.h>
+#include <klib-macros.h>
 
 #if !defined(__ARCH_RISCV32_NOOP) && !defined(__ARCH_RISCV64_NOOP)
 typedef union {

--- a/tests/softprefetchtest/src/softprefetch.S
+++ b/tests/softprefetchtest/src/softprefetch.S
@@ -119,7 +119,7 @@ enable_vm:
   la a1, page_table_1
   srl a1, a1, RISCV_PGSHIFT
   or a1, a1, a0
-  csrw sptbr, a1
+  csrw satp, a1
   sfence.vma
 
   # Enter supervisor mode and make sure correct page is accessed


### PR DESCRIPTION
This commits replaced the CSR name `sptbr` in source files with `satp`. The new code is checked to make sure this change does not break the functions modified. But further checkes might be required to make sure the tests are not broken.