### PR TITLE
[feat] add exhaustive tests and fast mode for BF16 extensions

### DIFF
--- a/am/arch/riscv64-noop.mk
+++ b/am/arch/riscv64-noop.mk
@@ -19,7 +19,7 @@ AM_SRCS := noop/isa/riscv/trm.c \
            dummy/mpe.c \
            nemu/isa/riscv/boot/start.S
 
-CFLAGS  += -I$(AM_HOME)/am/src/nemu/include -DISA_H=\"riscv.h\"
+CFLAGS  += -I$(AM_HOME)/am/src/nemu/include -I$(AM_HOME)/am/src/xs/include -DISA_H=\"riscv.h\"
 
 ASFLAGS += -DMAINARGS=\"$(mainargs)\"
 .PHONY: $(AM_HOME)/am/src/nemu/common/mainargs.S

--- a/tests/bf16-fast/Makefile
+++ b/tests/bf16-fast/Makefile
@@ -1,0 +1,6 @@
+NAME = bf16fast
+SRCS = ../bf16/bf16.c ../bf16/test_scalar.c ../bf16/test_vec.c main.c
+INC_DIR += $(APP_DIR)/../bf16/
+MARCH ?= rv64gc_zba_zbb_zbc_zbs_zbkb_zbkc_zbkx_zknd_zkne_zknh_zkr_zksed_zksh_zkt_zfbfmin_zvfbfwma_zvfbfmin_zfhmin
+
+include $(AM_HOME)/Makefile.app

--- a/tests/bf16-fast/main.c
+++ b/tests/bf16-fast/main.c
@@ -1,0 +1,18 @@
+#include "bf16.h"
+#include <klib.h>
+#include <stdint.h>
+
+int main() {
+  printf("=== BF16 Fast Function Tests ===\n\n");
+  asm volatile("fsrm zero" : : : "memory");
+  INIT();
+
+  test_float_to_bf16();
+  test_vfncvtbf16();
+  test_vfwcvtbf16();
+  test_vfwmaccbf16();
+  test_vfwmaccbf16_vf();
+
+  printf("=== Fast Tests Completed ===\n");
+  return 0;
+}

--- a/tests/bf16/bf16.c
+++ b/tests/bf16/bf16.c
@@ -12,6 +12,10 @@ uint16_t float_to_bf16(float f) {
   return (uint16_t)bf;
 }
 
+void set_rounding_mode(int rm) {
+  asm volatile("csrw frm, %0" : : "r"(rm) : "memory");
+}
+
 float bf16_to_float(uint16_t bf) {
   float f;
   asm volatile("fmv.h.x ft0, %1\n"
@@ -58,9 +62,17 @@ float fmv_h_x(uint32_t half_bits) {
 
 // Software implementations
 uint16_t float_to_bf16_soft(float f) {
+  return float_to_bf16_soft_rm(f, 0);
+}
+
+uint16_t float_to_bf16_soft_rm(float f, int rm) {
   float_bits fb;
   fb.f = f;
   uint32_t abs = fb.u & 0x7FFFFFFF;
+  uint32_t hi = fb.u >> 16;
+  uint32_t lo = fb.u & 0xFFFF;
+  uint32_t sign = fb.u >> 31;
+  int increment = 0;
 
   if ((abs & 0x7F800000) == 0x7F800000) {
     uint16_t bf = (uint16_t)(fb.u >> 16);
@@ -70,7 +82,28 @@ uint16_t float_to_bf16_soft(float f) {
     return bf;
   }
 
-  return (uint16_t)((fb.u + 0x7FFF + ((fb.u >> 16) & 1)) >> 16);
+  switch (rm) {
+  case 0: // RNE: round to nearest, ties to even
+    increment = (lo > 0x8000) || ((lo == 0x8000) && (hi & 1));
+    break;
+  case 1: // RTZ: round toward zero
+    increment = 0;
+    break;
+  case 2: // RDN: round down toward -inf
+    increment = sign && (lo != 0);
+    break;
+  case 3: // RUP: round up toward +inf
+    increment = !sign && (lo != 0);
+    break;
+  case 4: // RMM: round to nearest, ties to max magnitude
+    increment = lo >= 0x8000;
+    break;
+  default:
+    increment = (lo > 0x8000) || ((lo == 0x8000) && (hi & 1));
+    break;
+  }
+
+  return (uint16_t)(hi + increment);
 }
 
 float bf16_to_float_soft(uint16_t bf) {

--- a/tests/bf16/bf16.c
+++ b/tests/bf16/bf16.c
@@ -60,47 +60,22 @@ float fmv_h_x(uint32_t half_bits) {
 uint16_t float_to_bf16_soft(float f) {
   float_bits fb;
   fb.f = f;
-  uint32_t sign = (fb.u >> 31) & 0x1;
-  uint32_t exponent = (fb.u >> 23) & 0xFF;
-  uint32_t mantissa = fb.u & 0x7FFFFF;
+  uint32_t abs = fb.u & 0x7FFFFFFF;
 
-  if (exponent == 0xFF) {
-    // NaN or infinity
-    return (sign << 15) | 0x7F80 | (mantissa >> 16);
-  } else if (exponent == 0) {
-    // Zero or denormal
-    return (sign << 15);
+  if ((abs & 0x7F800000) == 0x7F800000) {
+    uint16_t bf = (uint16_t)(fb.u >> 16);
+    if (abs & 0x007FFFFF) {
+      bf |= 0x0040; // Preserve NaN while quieting signaling NaNs.
+    }
+    return bf;
   }
 
-  // Normal number: round to nearest even
-  uint32_t rounding = (mantissa >> 15) & 1; // Highest bit of discarded part
-  uint32_t sticky =
-      (mantissa & 0x7FFF) != 0; // Whether discarded part has non-zero bits
-  mantissa = (mantissa >> 16) + (rounding & sticky); // Carry
-  // Handle exponent overflow due to carry (very rare case)
-  if (mantissa == 0x80) {
-    mantissa = 0;
-    exponent++;
-  }
-  return (sign << 15) | (exponent << 7) | mantissa;
+  return (uint16_t)((fb.u + 0x7FFF + ((fb.u >> 16) & 1)) >> 16);
 }
 
 float bf16_to_float_soft(uint16_t bf) {
   float_bits fb;
-  uint32_t sign = (bf >> 15) & 0x1;
-  uint32_t exponent = (bf >> 7) & 0xFF;
-  uint32_t mantissa = bf & 0x7F;
-
-  if (exponent == 0xFF) {
-    // NaN or infinity
-    fb.u = (sign << 31) | 0x7F800000 | (mantissa << 16);
-  } else if (exponent == 0) {
-    // Denormal or zero: preserve mantissa
-    fb.u = (sign << 31) | (mantissa << 16);
-  } else {
-    // Normal case
-    fb.u = (sign << 31) | (exponent << 23) | (mantissa << 16);
-  }
+  fb.u = (uint32_t)bf << 16;
   return fb.f;
 }
 
@@ -197,3 +172,24 @@ int bf16_is_nan(uint16_t bf) {
 
 /* Get sign bit of bf16 */
 int bf16_get_sign(uint16_t bf) { return (bf >> 15) & 0x1; }
+
+int bf16_matches_float_conversion(float input, uint16_t actual,
+                                  uint16_t expected) {
+  if (is_nan(input)) {
+    return bf16_is_nan(actual);
+  }
+  if (is_inf(input)) {
+    return bf16_is_inf(actual) && (bf16_get_sign(actual) == get_sign(input));
+  }
+  return actual == expected;
+}
+
+int float_matches_bf16_conversion(uint16_t input, float actual) {
+  if (bf16_is_nan(input)) {
+    return is_nan(actual);
+  }
+
+  float_bits actual_bits;
+  actual_bits.f = actual;
+  return actual_bits.u == ((uint32_t)input << 16);
+}

--- a/tests/bf16/bf16.h
+++ b/tests/bf16/bf16.h
@@ -85,6 +85,10 @@ int bf16_is_nan(uint16_t bf);
 /* Get sign bit of bf16 */
 int bf16_get_sign(uint16_t bf);
 
+int bf16_matches_float_conversion(float input, uint16_t actual,
+                                  uint16_t expected);
+int float_matches_bf16_conversion(uint16_t input, float actual);
+
 /* ------------------------------------------------------------------------- */
 /* Test functions */
 

--- a/tests/bf16/bf16.h
+++ b/tests/bf16/bf16.h
@@ -45,6 +45,7 @@ typedef union {
 
 // Function prototypes
 uint16_t float_to_bf16(float f);
+void set_rounding_mode(int rm);
 float bf16_to_float(uint16_t bf);
 void store_half(uint16_t *ptr, float val);
 float load_half(const uint16_t *ptr);
@@ -53,6 +54,7 @@ float fmv_h_x(uint32_t half_bits);
 
 // Software implementations
 uint16_t float_to_bf16_soft(float f);
+uint16_t float_to_bf16_soft_rm(float f, int rm);
 float bf16_to_float_soft(uint16_t bf);
 void store_half_soft(uint16_t *ptr, float val);
 float load_half_soft(const uint16_t *ptr);

--- a/tests/bf16/test_scalar.c
+++ b/tests/bf16/test_scalar.c
@@ -48,6 +48,11 @@ static uint32_t bf16_test_rand(void) {
   return bf16_test_rand_state;
 }
 
+static const char *rounding_mode_name(int rm) {
+  static const char *names[] = {"RNE", "RTZ", "RDN", "RUP", "RMM"};
+  return (rm >= 0 && rm < 5) ? names[rm] : "UNKNOWN";
+}
+
 static void test_float_to_bf16_boundary_bits(void) {
   typedef struct {
     uint32_t input_bits;
@@ -98,38 +103,65 @@ static void test_float_to_bf16_boundary_bits(void) {
   printf("Boundary bit-pattern passed %d/%d.\n\n", pass_count, num_cases);
 }
 
-static void test_bf16_to_float_all_bits(void) {
+static void test_float_to_bf16_rounding_modes(void) {
+  typedef struct {
+    uint32_t input_bits;
+    const char *desc;
+  } rm_case_t;
+
+  static const rm_case_t rm_cases[] = {
+      {0x3F808000u, "+1.00390625 tie, even low BF16 LSB"},
+      {0x3F818000u, "+1.01171875 tie, odd low BF16 LSB"},
+      {0x3F800001u, "+1.0 plus tiny fraction"},
+      {0x3F80FFFFu, "+1.0 just below next BF16"},
+      {0xBF808000u, "-1.00390625 tie"},
+      {0xBF800001u, "-1.0 minus tiny fraction"},
+      {0xBF80FFFFu, "-1.0 just below next BF16 magnitude"},
+      {0x00008000u, "+subnormal half-way to min BF16 subnormal"},
+      {0x80008000u, "-subnormal half-way to min BF16 subnormal"},
+      {0x7F7F7FFFu, "+max finite below overflow tie"},
+      {0x7F7F8000u, "+max finite overflow tie"},
+      {0xFF7F8000u, "-max finite overflow tie"},
+  };
+
   int fail_count = 0;
+  int num_cases = sizeof(rm_cases) / sizeof(rm_cases[0]);
 
-  printf("Exhaustive bit-pattern test (bf16 -> float):\n");
-  for (uint32_t i = 0; i <= 0xFFFFu; i++) {
-    uint16_t input = (uint16_t)i;
-    float actual = bf16_to_float(input);
+  printf("Rounding mode test (float -> bf16):\n");
+  for (int rm = 0; rm <= 4; rm++) {
+    set_rounding_mode(rm);
+    for (int i = 0; i < num_cases; i++) {
+      float_bits input;
+      input.u = rm_cases[i].input_bits;
+      uint16_t expected = float_to_bf16_soft_rm(input.f, rm);
+      uint16_t actual = float_to_bf16(input.f);
 
-    if (!float_matches_bf16_conversion(input, actual)) {
-      if (fail_count < 8) {
-        float_bits actual_bits;
-        actual_bits.f = actual;
-        printf("%sFAIL%s: 0x%04x -> 0x%08x, expected 0x%08x\n",
-               COLOR_RED, COLOR_RESET, input, actual_bits.u,
-               (uint32_t)input << 16);
+      if (bf16_matches_float_conversion(input.f, actual, expected)) {
+        printf("%sPASS%s: [%s] %s (0x%08x) -> 0x%04x\n", COLOR_GREEN,
+               COLOR_RESET, rounding_mode_name(rm), rm_cases[i].desc,
+               rm_cases[i].input_bits, actual);
+      } else {
+        printf("%sFAIL%s: [%s] %s (0x%08x) -> 0x%04x, expected 0x%04x\n",
+               COLOR_RED, COLOR_RESET, rounding_mode_name(rm),
+               rm_cases[i].desc, rm_cases[i].input_bits, actual, expected);
+        fail_count++;
       }
-      fail_count++;
     }
   }
+  set_rounding_mode(0);
 
   if (fail_count == 0) {
-    printf("%sPASS%s: all 65536 bf16 values converted correctly.\n\n",
+    printf("%sPASS%s: all rounding modes matched scalar oracle.\n\n",
            COLOR_GREEN, COLOR_RESET);
   } else {
-    printf("%sFAIL%s: bf16_to_float failed %d/65536 cases.\n\n", COLOR_RED,
-           COLOR_RESET, fail_count);
+    printf("%sFAIL%s: rounding mode test failed %d/%d cases.\n\n", COLOR_RED,
+           COLOR_RESET, fail_count, num_cases * 5);
   }
 }
 
 static void test_float_to_bf16_random(void) {
   int fail_count = 0;
-  const int num_random = 4096;
+  const int num_random = 128;
 
   printf("Deterministic random test (float -> bf16):\n");
   for (int i = 0; i < num_random; i++) {
@@ -204,6 +236,7 @@ void test_store_load_half() {
 void test_float_to_bf16(void) {
   printf("Testing float_to_bf16:\n");
 
+  set_rounding_mode(0);
   int pass_count = 0;
 
   for (int i = 0; i < num_test_cases; i++) {
@@ -229,7 +262,8 @@ void test_float_to_bf16(void) {
   printf("Passed %d/%d tests.\n\n", pass_count, num_test_cases);
 
   test_float_to_bf16_boundary_bits();
-  test_bf16_to_float_all_bits();
+  test_float_to_bf16_rounding_modes();
+  set_rounding_mode(0);
   test_float_to_bf16_random();
 
   /* --------------------------------------------------------------------- */

--- a/tests/bf16/test_scalar.c
+++ b/tests/bf16/test_scalar.c
@@ -5,6 +5,7 @@ test_case_t test_cases[] = {
     // Normal numbers
     {1.0f, 0x3F80, "1.0"},
     {0.0f, 0x0000, "0.0"},
+    {-0.0f, 0x8000, "-0.0"},
     {-1.0f, 0xBF80, "-1.0"},
     {0.5f, 0x3F00, "0.5"},
     {-0.5f, 0xBF00, "-0.5"},
@@ -26,13 +27,134 @@ test_case_t test_cases[] = {
     {1.40129846e-45f, 0x0000, "Smallest positive denormal"},
     {1.0e-45f, 0x0000, "Rounds to 0"},
     {-1.40129846e-45f, 0x8000, "Smallest negative denormal"},
+    {0x1p-133f, 0x0001, "Smallest positive BF16 subnormal"},
+    {-0x1p-133f, 0x8001, "Smallest negative BF16 subnormal"},
+    {0x1p-126f, 0x0080, "Smallest positive BF16 normal"},
 
     // Edge cases
     {0.0078125f, 0x3C00, "2^-7"},
-    {65504.0f, 0x4780, "Largest normal number"},
+    {0x1.01p+0f, 0x3F80, "RNE tie with even BF16 LSB"},
+    {0x1.03p+0f, 0x3F82, "RNE tie with odd BF16 LSB"},
+    {0x1.fep+127f, 0x7F7F, "Largest finite BF16"},
+    {0x1.fffffep+127f, 0x7F80, "Largest finite FP32 rounds to +inf"},
 };
 
 int num_test_cases = sizeof(test_cases) / sizeof(test_cases[0]);
+
+static uint32_t bf16_test_rand_state = 0x6D2B79F5u;
+
+static uint32_t bf16_test_rand(void) {
+  bf16_test_rand_state = bf16_test_rand_state * 1664525u + 1013904223u;
+  return bf16_test_rand_state;
+}
+
+static void test_float_to_bf16_boundary_bits(void) {
+  typedef struct {
+    uint32_t input_bits;
+    uint16_t expected;
+    const char *desc;
+  } bit_case_t;
+
+  static const bit_case_t bit_cases[] = {
+      {0x00000000u, 0x0000, "+0"},
+      {0x80000000u, 0x8000, "-0"},
+      {0x00008000u, 0x0000, "Subnormal tie to +0"},
+      {0x00008001u, 0x0001, "Subnormal just above +0 tie"},
+      {0x00018000u, 0x0002, "Subnormal tie to even non-zero"},
+      {0x007FFFFFu, 0x0080, "Largest FP32 subnormal"},
+      {0x00800000u, 0x0080, "Smallest FP32 normal"},
+      {0x3F808000u, 0x3F80, "Normal tie to even"},
+      {0x3F818000u, 0x3F82, "Normal tie away from odd"},
+      {0x7F7F0000u, 0x7F7F, "Largest finite BF16 exact"},
+      {0x7F7F7FFFu, 0x7F7F, "Just below overflow tie"},
+      {0x7F7F8000u, 0x7F80, "Overflow tie to +inf"},
+      {0xFF7F8000u, 0xFF80, "Overflow tie to -inf"},
+      {0x7F800001u, 0x7FC0, "Positive signaling NaN"},
+      {0xFFBFFFFFu, 0xFFC0, "Negative NaN"},
+  };
+
+  int pass_count = 0;
+  int num_cases = sizeof(bit_cases) / sizeof(bit_cases[0]);
+
+  printf("Boundary bit-pattern test (float -> bf16):\n");
+  for (int i = 0; i < num_cases; i++) {
+    float_bits input;
+    input.u = bit_cases[i].input_bits;
+    uint16_t actual = float_to_bf16(input.f);
+    int ok = bf16_matches_float_conversion(input.f, actual,
+                                           bit_cases[i].expected);
+
+    if (ok) {
+      pass_count++;
+      printf("%sPASS%s: %s (0x%08x) -> 0x%04x\n", COLOR_GREEN, COLOR_RESET,
+             bit_cases[i].desc, bit_cases[i].input_bits, actual);
+    } else {
+      printf("%sFAIL%s: %s (0x%08x) -> 0x%04x, expected 0x%04x\n",
+             COLOR_RED, COLOR_RESET, bit_cases[i].desc,
+             bit_cases[i].input_bits, actual, bit_cases[i].expected);
+    }
+  }
+
+  printf("Boundary bit-pattern passed %d/%d.\n\n", pass_count, num_cases);
+}
+
+static void test_bf16_to_float_all_bits(void) {
+  int fail_count = 0;
+
+  printf("Exhaustive bit-pattern test (bf16 -> float):\n");
+  for (uint32_t i = 0; i <= 0xFFFFu; i++) {
+    uint16_t input = (uint16_t)i;
+    float actual = bf16_to_float(input);
+
+    if (!float_matches_bf16_conversion(input, actual)) {
+      if (fail_count < 8) {
+        float_bits actual_bits;
+        actual_bits.f = actual;
+        printf("%sFAIL%s: 0x%04x -> 0x%08x, expected 0x%08x\n",
+               COLOR_RED, COLOR_RESET, input, actual_bits.u,
+               (uint32_t)input << 16);
+      }
+      fail_count++;
+    }
+  }
+
+  if (fail_count == 0) {
+    printf("%sPASS%s: all 65536 bf16 values converted correctly.\n\n",
+           COLOR_GREEN, COLOR_RESET);
+  } else {
+    printf("%sFAIL%s: bf16_to_float failed %d/65536 cases.\n\n", COLOR_RED,
+           COLOR_RESET, fail_count);
+  }
+}
+
+static void test_float_to_bf16_random(void) {
+  int fail_count = 0;
+  const int num_random = 4096;
+
+  printf("Deterministic random test (float -> bf16):\n");
+  for (int i = 0; i < num_random; i++) {
+    float_bits input;
+    input.u = bf16_test_rand();
+    uint16_t expected = float_to_bf16_soft(input.f);
+    uint16_t actual = float_to_bf16(input.f);
+
+    if (!bf16_matches_float_conversion(input.f, actual, expected)) {
+      if (fail_count < 8) {
+        printf("%sFAIL%s: bits=0x%08x -> 0x%04x, expected 0x%04x\n",
+               COLOR_RED, COLOR_RESET, input.u, actual, expected);
+      }
+      fail_count++;
+    }
+  }
+
+  if (fail_count == 0) {
+    printf("%sPASS%s: %d random FP32 patterns matched software oracle.\n\n",
+           COLOR_GREEN, COLOR_RESET, num_random);
+  } else {
+    printf("%sFAIL%s: random float_to_bf16 failed %d/%d cases.\n\n",
+           COLOR_RED, COLOR_RESET, fail_count, num_random);
+  }
+}
 
 void test_store_load_half() {
   printf("Testing store_half and load_half:\n");
@@ -92,18 +214,7 @@ void test_float_to_bf16(void) {
 
     int ok = 0;
 
-    /* Special handling for NaN: As long as output is NaN, it's correct
-     * (mantissa doesn't need to match exactly) */
-    if (is_nan(f)) {
-      ok = bf16_is_nan(bf);
-    } else if (is_inf(f)) {
-      /* Infinity: Requires all 1s in exponent, 0s in mantissa, and matching
-       * sign */
-      ok = bf16_is_inf(bf) && (bf16_get_sign(bf) == get_sign(f));
-    } else {
-      /* Normal numbers: Direct bit pattern comparison */
-      ok = (bf == expected);
-    }
+    ok = bf16_matches_float_conversion(f, bf, expected);
 
     if (ok) {
       printf("%sPASS%s: %s (%g) -> 0x%04x (expected 0x%04x)\n", COLOR_GREEN,
@@ -116,6 +227,10 @@ void test_float_to_bf16(void) {
   }
 
   printf("Passed %d/%d tests.\n\n", pass_count, num_test_cases);
+
+  test_float_to_bf16_boundary_bits();
+  test_bf16_to_float_all_bits();
+  test_float_to_bf16_random();
 
   /* --------------------------------------------------------------------- */
   /* Reverse conversion test (float -> bf16 -> float) */

--- a/tests/bf16/test_vec.c
+++ b/tests/bf16/test_vec.c
@@ -12,6 +12,85 @@ static int active_lanes(int base, int total) {
   return lanes < 4 ? lanes : 4;
 }
 
+static const char *vec_rounding_mode_name(int rm) {
+  static const char *names[] = {"RNE", "RTZ", "RDN", "RUP", "RMM"};
+  return (rm >= 0 && rm < 5) ? names[rm] : "UNKNOWN";
+}
+
+static int fp32_same_or_both_nan(float actual, float expected) {
+  if (is_nan(actual) || is_nan(expected)) {
+    return is_nan(actual) && is_nan(expected);
+  }
+
+  float_bits actual_bits;
+  float_bits expected_bits;
+  actual_bits.f = actual;
+  expected_bits.f = expected;
+  return actual_bits.u == expected_bits.u;
+}
+
+static void run_vfncvtbf16_4(float *values, uint16_t *out, int rm) {
+  asm volatile("csrw frm, %2\n"
+               "vsetivli zero, 4, e32, m1, ta, ma\n"
+               "vle32.v v2, (%0)\n"
+               "vsetivli zero, 4, e16, m1, ta, ma\n"
+               "vfncvtbf16.f.f.w v0, v2\n"
+               "vse16.v v0, (%1)\n"
+               "fence rw, rw\n"
+               :
+               : "r"(values), "r"(out), "r"(rm)
+               : "v0", "v1", "v2", "memory");
+}
+
+static void test_vfncvtbf16_rounding_modes(void) {
+  float values[4];
+  uint16_t results[4];
+  static const uint32_t input_bits[] = {
+      0x3F808000u, 0x3F800001u, 0xBF808000u, 0xBF800001u,
+      0x3F818000u, 0x3F80FFFFu, 0xBF818000u, 0xBF80FFFFu,
+      0x00008000u, 0x80008000u, 0x7F7F7FFFu, 0xFF7F7FFFu,
+  };
+  int num_inputs = sizeof(input_bits) / sizeof(input_bits[0]);
+  int fail_count = 0;
+
+  printf("\nTest 4: Rounding modes\n");
+  for (int rm = 0; rm <= 4; rm++) {
+    for (int base = 0; base < num_inputs; base += 4) {
+      for (int i = 0; i < 4; i++) {
+        float_bits input;
+        input.u = input_bits[base + i];
+        values[i] = input.f;
+        results[i] = 0xDEAD;
+      }
+
+      run_vfncvtbf16_4(values, results, rm);
+
+      for (int i = 0; i < 4; i++) {
+        uint16_t expected = float_to_bf16_soft_rm(values[i], rm);
+        if (bf16_matches_float_conversion(values[i], results[i], expected)) {
+          printf("%sPASS%s: [%s] bits=0x%08x -> 0x%04x\n", COLOR_GREEN,
+                 COLOR_RESET, vec_rounding_mode_name(rm), input_bits[base + i],
+                 results[i]);
+        } else {
+          printf("%sFAIL%s: [%s] bits=0x%08x -> 0x%04x, expected 0x%04x\n",
+                 COLOR_RED, COLOR_RESET, vec_rounding_mode_name(rm),
+                 input_bits[base + i], results[i], expected);
+          fail_count++;
+        }
+      }
+    }
+  }
+  set_rounding_mode(0);
+
+  if (fail_count == 0) {
+    printf("%sPASS%s: vfncvtbf16 rounding modes matched oracle.\n",
+           COLOR_GREEN, COLOR_RESET);
+  } else {
+    printf("%sFAIL%s: vfncvtbf16 rounding modes failed %d/%d lanes.\n",
+           COLOR_RED, COLOR_RESET, fail_count, num_inputs * 5);
+  }
+}
+
 void test_vfncvtbf16() {
   printf("Testing vfncvtbf16.f.f.w (Vector convert FP32 to BF16):\n");
 
@@ -101,7 +180,7 @@ void test_vfncvtbf16() {
   printf("\nTest 3: Deterministic random operation\n");
 
   int random_fail = 0;
-  for (int iter = 0; iter < 64; iter++) {
+  for (int iter = 0; iter < 32; iter++) {
     for (int i = 0; i < 4; i++) {
       float_bits input;
       input.u = vec_rand();
@@ -136,12 +215,14 @@ void test_vfncvtbf16() {
   }
 
   if (random_fail == 0) {
-    printf("%sPASS%s: vfncvtbf16 random conversion matched 256 lanes.\n",
+    printf("%sPASS%s: vfncvtbf16 random conversion matched 128 lanes.\n",
            COLOR_GREEN, COLOR_RESET);
   } else {
-    printf("%sFAIL%s: vfncvtbf16 random conversion failed %d/256 lanes.\n",
+    printf("%sFAIL%s: vfncvtbf16 random conversion failed %d/128 lanes.\n",
            COLOR_RED, COLOR_RESET, random_fail);
   }
+
+  test_vfncvtbf16_rounding_modes();
 
   printf("\nvfncvtbf16.f.f.w test completed\n\n");
 }
@@ -242,7 +323,7 @@ void test_vfwcvtbf16() {
   printf("\nTest 3: Deterministic random operation\n");
 
   int random_fail = 0;
-  for (int iter = 0; iter < 64; iter++) {
+  for (int iter = 0; iter < 32; iter++) {
     for (int i = 0; i < 4; i++) {
       bf16_values[i] = (uint16_t)(vec_rand() >> 16);
       results[i] = -3.0f;
@@ -276,51 +357,94 @@ void test_vfwcvtbf16() {
   }
 
   if (random_fail == 0) {
-    printf("%sPASS%s: vfwcvtbf16 random conversion matched 256 lanes.\n",
+    printf("%sPASS%s: vfwcvtbf16 random conversion matched 128 lanes.\n",
            COLOR_GREEN, COLOR_RESET);
   } else {
-    printf("%sFAIL%s: vfwcvtbf16 random conversion failed %d/256 lanes.\n",
+    printf("%sFAIL%s: vfwcvtbf16 random conversion failed %d/128 lanes.\n",
            COLOR_RED, COLOR_RESET, random_fail);
   }
 
   printf("vfwcvtbf16.f.f.v test completed\n\n");
 }
 
-// Expand vfwmaccbf16.vv instruction using vfwcvtbf16 and vfmacc
-void expand_vfwmaccbf_vf(uint16_t *vs1_bf16, uint16_t *vs2_bf16,
-                         float *vd_fp32) {
-  asm volatile("csrwi frm,0 \n"
-               "vsetivli zero, 4, e16, m1, ta, ma\n"
+// Expand vfwmaccbf16.vv instruction using vfwcvtbf16 and vfmacc.
+static void expand_vfwmaccbf16_vv(uint16_t *vs1_bf16, uint16_t *vs2_bf16,
+                                  float *vd_fp32, int rm, int vl) {
+  asm volatile("csrw frm, %3\n"
+               "vsetivli zero, 4, e32, m1, tu, mu\n"
+               "vle32.v v4, (%2)\n"
+               "vsetvli zero, %4, e16, m1, tu, mu\n"
                "vle16.v v0, (%0)\n"
                "vfwcvtbf16.f.f.v v2, v0\n"
-               "vsetivli zero, 4, e16, m1, ta, ma\n"
                "vle16.v v1, (%1)\n"
                "vfwcvtbf16.f.f.v v6, v1\n"
-               "vsetivli zero, 4, e32, m1, ta, ma\n"
-               "vle32.v v4, (%2)\n"
+               "vsetvli zero, %4, e32, m1, tu, mu\n"
                "vfmacc.vv v4,v2,v6\n"
-               "vsetivli zero, 4, e32, m1, ta, ma\n"
+               "vsetivli zero, 4, e32, m1, tu, mu\n"
                "vse32.v v4, (%2)\n"
                "fence rw, rw\n"
                :
-               : "r"(vs1_bf16), "r"(vs2_bf16), "r"(vd_fp32)
+               : "r"(vs1_bf16), "r"(vs2_bf16), "r"(vd_fp32), "r"(rm),
+                 "r"(vl)
                : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "memory");
 }
 
-void vfwmaccbf_vf(uint16_t *vs1_bf16, uint16_t *vs2_bf16, float *vd_fp32) {
-  asm volatile("csrwi frm,0 \n"
-               "vsetivli zero, 4, e32, m1, ta, ma\n"
+static void run_vfwmaccbf16_vv(uint16_t *vs1_bf16, uint16_t *vs2_bf16,
+                               float *vd_fp32, int rm, int vl) {
+  asm volatile("csrw frm, %3\n"
+               "vsetivli zero, 4, e32, m1, tu, mu\n"
                "vle32.v v4, (%2)\n"
-               "vsetivli zero, 4, e16, m1, ta, ma\n"
+               "vsetvli zero, %4, e16, m1, tu, mu\n"
                "vle16.v v0, (%0)\n"
                "vle16.v v2, (%1)\n"
                "vfwmaccbf16.vv v4, v0, v2\n"
-               "vsetivli zero, 4, e32, m1, ta, ma\n"
+               "vsetivli zero, 4, e32, m1, tu, mu\n"
                "vse32.v v4, (%2)\n"
                "fence rw, rw\n"
                :
-               : "r"(vs1_bf16), "r"(vs2_bf16), "r"(vd_fp32)
+               : "r"(vs1_bf16), "r"(vs2_bf16), "r"(vd_fp32), "r"(rm),
+                 "r"(vl)
                : "v0", "v1", "v2", "v3", "v4", "v5", "memory");
+}
+
+static void expand_vfwmaccbf16_vf(uint16_t rs1_bf16, uint16_t *vs2,
+                                  float *vd, int rm, int vl) {
+  asm volatile("csrw frm, %3\n"
+               "fmv.h.x ft0, %0\n"
+               "fcvt.s.bf16 ft1, ft0\n"
+               "vsetivli zero, 4, e32, m1, tu, mu\n"
+               "vle32.v v4, (%1)\n"
+               "vsetvli zero, %4, e16, m1, tu, mu\n"
+               "vle16.v v0, (%2)\n"
+               "vfwcvtbf16.f.f.v v2, v0\n"
+               "vsetvli zero, %4, e32, m1, tu, mu\n"
+               "vfmacc.vf v4, ft1, v2\n"
+               "vsetivli zero, 4, e32, m1, tu, mu\n"
+               "vse32.v v4, (%1)\n"
+               "fence rw, rw\n"
+               :
+               : "r"((uint32_t)rs1_bf16), "r"(vd), "r"(vs2), "r"(rm),
+                 "r"(vl)
+               : "ft0", "ft1", "v0", "v1", "v2", "v3", "v4", "v5",
+                 "memory");
+}
+
+static void run_vfwmaccbf16_vf(uint16_t rs1_bf16, uint16_t *vs2, float *vd,
+                               int rm, int vl) {
+  asm volatile("csrw frm, %3\n"
+               "fmv.h.x ft0, %0\n"
+               "vsetivli zero, 4, e32, m1, tu, mu\n"
+               "vle32.v v4, (%1)\n"
+               "vsetvli zero, %4, e16, m1, tu, mu\n"
+               "vle16.v v2, (%2)\n"
+               "vfwmaccbf16.vf v4, ft0, v2\n"
+               "vsetivli zero, 4, e32, m1, tu, mu\n"
+               "vse32.v v4, (%1)\n"
+               "fence rw, rw\n"
+               :
+               : "r"((uint32_t)rs1_bf16), "r"(vd), "r"(vs2), "r"(rm),
+                 "r"(vl)
+               : "ft0", "v2", "v3", "v4", "v5", "memory");
 }
 // Test vfwmaccbf16.vv (Vector widening fused multiply-accumulate)
 void test_vfwmaccbf16() {
@@ -354,6 +478,9 @@ void test_vfwmaccbf16() {
 
       // NaN cases
       {0x7FC0, 0x3F80, 0.0f, NAN, "NaN * 1.0 + 0.0"},
+      {0x7F80, 0x0000, 1.0f, NAN, "+inf * 0.0 + 1.0"},
+      {0x0001, 0x3F80, 0.0f, 0x1p-133f, "min subnormal * 1.0 + 0.0"},
+      {0x7F7F, 0x7F7F, 0.0f, INFINITY, "max finite * max finite + 0.0"},
   };
 
   int num_wmacc_tests = sizeof(wmacc_tests) / sizeof(wmacc_tests[0]);
@@ -364,28 +491,26 @@ void test_vfwmaccbf16() {
   uint16_t vs1_bf16[4];
   uint16_t vs2_bf16[4];
   float vd_fp32[4];
-  // float results_fp32[4];
-
-  for (int base = 0; base + 4 <= num_wmacc_tests; base += 4) {
-    for (int i = base; i < base + 4; i++) {
-      vs1_bf16[i - base] = wmacc_tests[i].vs1;
-      vs2_bf16[i - base] = wmacc_tests[i].vs2;
-      vd_fp32[i - base] = wmacc_tests[i].vd;
+  for (int base = 0; base < num_wmacc_tests; base += 4) {
+    int lanes = active_lanes(base, num_wmacc_tests);
+    for (int i = 0; i < 4; i++) {
+      vs1_bf16[i] = i < lanes ? wmacc_tests[base + i].vs1 : 0;
+      vs2_bf16[i] = i < lanes ? wmacc_tests[base + i].vs2 : 0;
+      vd_fp32[i] = i < lanes ? wmacc_tests[base + i].vd : -99.0f;
     }
 
-    // expand_vfwmaccbf_vf(vs1_bf16, vs2_bf16, vd_fp32);
-    vfwmaccbf_vf(vs1_bf16, vs2_bf16, vd_fp32);
+    run_vfwmaccbf16_vv(vs1_bf16, vs2_bf16, vd_fp32, 0, lanes);
 
     // Check results
-    for (int i = base; i < base + 4; i++) {
-      float expected = wmacc_tests[i].expected;
-      float actual = vd_fp32[i - base];
+    for (int i = 0; i < lanes; i++) {
+      float expected = wmacc_tests[base + i].expected;
+      float actual = vd_fp32[i];
       if (float_equal(actual, expected, 1e-6f, 1e-3f)) {
         printf("%sPASS%s: %s -> %g\n", COLOR_GREEN, COLOR_RESET,
-               wmacc_tests[i].desc, actual);
+               wmacc_tests[base + i].desc, actual);
       } else {
         printf("%sFAIL%s: %s -> %g, expected %g\n", COLOR_RED, COLOR_RESET,
-               wmacc_tests[i].desc, actual, expected);
+               wmacc_tests[base + i].desc, actual, expected);
       }
     }
   }
@@ -440,23 +565,141 @@ void test_vfwmaccbf16() {
       }
     }
   }
+
+  // Test 3: Directed boundary operation against expanded sequence
+  printf("\nTest 3: Directed boundary operation\n");
+  typedef struct {
+    uint16_t vs1[4];
+    uint16_t vs2[4];
+    uint32_t vd_bits[4];
+    int rm;
+    int vl;
+    const char *desc;
+  } vv_boundary_t;
+
+  static const vv_boundary_t vv_boundary_tests[] = {
+      {{0x0001, 0x8001, 0x7F7F, 0xFF7F},
+       {0x3F80, 0x4000, 0x7F7F, 0x7F7F},
+       {0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u},
+       0,
+       4,
+       "subnormal and max finite operands"},
+      {{0x7F80, 0x0000, 0x7F80, 0xFF80},
+       {0x0000, 0x7F80, 0xFF80, 0xFF80},
+       {0x3F800000u, 0x3F800000u, 0x00000000u, 0x00000000u},
+       0,
+       4,
+       "inf-zero and inf sign combinations"},
+      {{0x3F80, 0xBF80, 0x3F80, 0x4000},
+       {0xBF80, 0x3F80, 0x3F80, 0x4000},
+       {0x3F800000u, 0x3F800000u, 0x7FC00000u, 0x7F800000u},
+       0,
+       3,
+       "cancellation, NaN accumulator, tail undisturbed"},
+      {{0x3F81, 0xBF81, 0x3F81, 0xBF81},
+       {0x3F81, 0x3F81, 0xBF81, 0xBF81},
+       {0x3F000001u, 0xBF000001u, 0x3EAAAAABu, 0xBEAAAAABu},
+       4,
+       4,
+       "non-exact products under RMM"},
+  };
+
+  int boundary_fail = 0;
+  int num_boundary_tests =
+      sizeof(vv_boundary_tests) / sizeof(vv_boundary_tests[0]);
+  for (int t = 0; t < num_boundary_tests; t++) {
+    float actual[4];
+    float expected[4];
+    for (int i = 0; i < 4; i++) {
+      float_bits vd_bits;
+      vd_bits.u = vv_boundary_tests[t].vd_bits[i];
+      actual[i] = vd_bits.f;
+      expected[i] = vd_bits.f;
+    }
+
+    run_vfwmaccbf16_vv((uint16_t *)vv_boundary_tests[t].vs1,
+                       (uint16_t *)vv_boundary_tests[t].vs2, actual,
+                       vv_boundary_tests[t].rm, vv_boundary_tests[t].vl);
+    expand_vfwmaccbf16_vv((uint16_t *)vv_boundary_tests[t].vs1,
+                          (uint16_t *)vv_boundary_tests[t].vs2, expected,
+                          vv_boundary_tests[t].rm, vv_boundary_tests[t].vl);
+
+    for (int i = 0; i < 4; i++) {
+      if (fp32_same_or_both_nan(actual[i], expected[i])) {
+        printf("%sPASS%s: [%s] %s lane%d -> %g\n", COLOR_GREEN, COLOR_RESET,
+               vec_rounding_mode_name(vv_boundary_tests[t].rm),
+               vv_boundary_tests[t].desc, i, actual[i]);
+      } else {
+        float_bits actual_bits;
+        float_bits expected_bits;
+        actual_bits.f = actual[i];
+        expected_bits.f = expected[i];
+        printf("%sFAIL%s: [%s] %s lane%d -> 0x%08x, expected 0x%08x\n",
+               COLOR_RED, COLOR_RESET,
+               vec_rounding_mode_name(vv_boundary_tests[t].rm),
+               vv_boundary_tests[t].desc, i, actual_bits.u, expected_bits.u);
+        boundary_fail++;
+      }
+    }
+  }
+
+  if (boundary_fail == 0) {
+    printf("%sPASS%s: vfwmaccbf16.vv boundary cases matched expansion.\n",
+           COLOR_GREEN, COLOR_RESET);
+  } else {
+    printf("%sFAIL%s: vfwmaccbf16.vv boundary cases failed %d/%d lanes.\n",
+           COLOR_RED, COLOR_RESET, boundary_fail, num_boundary_tests * 4);
+  }
+
+  // Test 4: Deterministic random operation against expanded sequence
+  printf("\nTest 4: Deterministic random operation\n");
+  int random_fail = 0;
+  for (int iter = 0; iter < 32; iter++) {
+    float actual[4];
+    float expected[4];
+    int rm = iter % 5;
+
+    for (int i = 0; i < 4; i++) {
+      float_bits vd_bits;
+      vs1_bf16[i] = (uint16_t)(vec_rand() >> 16);
+      vs2_bf16[i] = (uint16_t)(vec_rand() >> 16);
+      vd_bits.u = vec_rand();
+      actual[i] = vd_bits.f;
+      expected[i] = vd_bits.f;
+    }
+
+    run_vfwmaccbf16_vv(vs1_bf16, vs2_bf16, actual, rm, 4);
+    expand_vfwmaccbf16_vv(vs1_bf16, vs2_bf16, expected, rm, 4);
+
+    for (int i = 0; i < 4; i++) {
+      if (!fp32_same_or_both_nan(actual[i], expected[i])) {
+        if (random_fail < 8) {
+          float_bits actual_bits;
+          float_bits expected_bits;
+          actual_bits.f = actual[i];
+          expected_bits.f = expected[i];
+          printf("%sFAIL%s: random [%s] lane%d -> 0x%08x, expected 0x%08x\n",
+                 COLOR_RED, COLOR_RESET, vec_rounding_mode_name(rm), i,
+                 actual_bits.u, expected_bits.u);
+        }
+        random_fail++;
+      }
+    }
+  }
+
+  if (random_fail == 0) {
+    printf("%sPASS%s: vfwmaccbf16.vv random test matched 128 lanes.\n",
+           COLOR_GREEN, COLOR_RESET);
+  } else {
+    printf("%sFAIL%s: vfwmaccbf16.vv random test failed %d/128 lanes.\n",
+           COLOR_RED, COLOR_RESET, random_fail);
+  }
+
   printf("\nvfwmaccbf16.vv test completed\n\n");
 }
 
 void do_vfwmaccbf16_vf(uint16_t rs1_bf16, uint16_t *vs2, float *vd) {
-  asm volatile("csrwi frm,0 \n"
-               "fmv.h.x ft0, %0\n"
-               "vsetivli zero, 4, e32, m1, ta, ma\n"
-               "vle32.v v4, (%1)\n"
-               "vsetivli zero, 4, e16, m1, ta, ma\n"
-               "vle16.v v2, (%2)\n"
-               "vfwmaccbf16.vf v4, ft0, v2\n"
-               "vsetivli zero, 4, e32, m1, ta, ma\n"
-               "vse32.v v4, (%1)\n"
-               "fence rw, rw\n"
-               :
-               : "r"((uint32_t)rs1_bf16), "r"(vd), "r"(vs2)
-               : "ft0", "v2", "v3", "v4", "v5", "memory");
+  run_vfwmaccbf16_vf(rs1_bf16, vs2, vd, 0, 4);
 }
 
 // Test vfwmaccbf16.vf (Vector-scalar widening fused multiply-accumulate)
@@ -579,6 +822,136 @@ void test_vfwmaccbf16_vf() {
                actual, expected_unch);
       }
     }
+  }
+
+  // Test 3: Directed boundary operation against expanded sequence
+  printf("\nTest 3: Directed boundary operation\n");
+  typedef struct {
+    uint16_t rs1;
+    uint16_t vs2[4];
+    uint32_t vd_bits[4];
+    int rm;
+    int vl;
+    const char *desc;
+  } vf_boundary_t;
+
+  static const vf_boundary_t vf_boundary_tests[] = {
+      {0x0001,
+       {0x3F80, 0x4000, 0x8001, 0x7F7F},
+       {0x00000000u, 0x00000000u, 0x00000000u, 0x00000000u},
+       0,
+       4,
+       "scalar min subnormal"},
+      {0x7F80,
+       {0x0000, 0x8000, 0x3F80, 0xBF80},
+       {0x3F800000u, 0xBF800000u, 0x00000000u, 0x00000000u},
+       0,
+       4,
+       "scalar +inf with zero and finite vector"},
+      {0x0000,
+       {0x7F80, 0xFF80, 0x7FC0, 0x3F80},
+       {0x3F800000u, 0xBF800000u, 0x00000000u, 0x7F800000u},
+       0,
+       3,
+       "scalar zero with inf/NaN vector and tail"},
+      {0x3F81,
+       {0x3F81, 0xBF81, 0x7F7F, 0xFF7F},
+       {0x3F000001u, 0xBF000001u, 0x00000000u, 0x00000000u},
+       4,
+       4,
+       "non-exact products under RMM"},
+  };
+
+  int boundary_fail = 0;
+  int num_boundary_tests =
+      sizeof(vf_boundary_tests) / sizeof(vf_boundary_tests[0]);
+  for (int t = 0; t < num_boundary_tests; t++) {
+    float actual[4];
+    float expected[4];
+    for (int i = 0; i < 4; i++) {
+      float_bits vd_bits;
+      vd_bits.u = vf_boundary_tests[t].vd_bits[i];
+      actual[i] = vd_bits.f;
+      expected[i] = vd_bits.f;
+    }
+
+    run_vfwmaccbf16_vf(vf_boundary_tests[t].rs1,
+                       (uint16_t *)vf_boundary_tests[t].vs2, actual,
+                       vf_boundary_tests[t].rm, vf_boundary_tests[t].vl);
+    expand_vfwmaccbf16_vf(vf_boundary_tests[t].rs1,
+                          (uint16_t *)vf_boundary_tests[t].vs2, expected,
+                          vf_boundary_tests[t].rm, vf_boundary_tests[t].vl);
+
+    for (int i = 0; i < 4; i++) {
+      if (fp32_same_or_both_nan(actual[i], expected[i])) {
+        printf("%sPASS%s: [%s] %s lane%d -> %g\n", COLOR_GREEN, COLOR_RESET,
+               vec_rounding_mode_name(vf_boundary_tests[t].rm),
+               vf_boundary_tests[t].desc, i, actual[i]);
+      } else {
+        float_bits actual_bits;
+        float_bits expected_bits;
+        actual_bits.f = actual[i];
+        expected_bits.f = expected[i];
+        printf("%sFAIL%s: [%s] %s lane%d -> 0x%08x, expected 0x%08x\n",
+               COLOR_RED, COLOR_RESET,
+               vec_rounding_mode_name(vf_boundary_tests[t].rm),
+               vf_boundary_tests[t].desc, i, actual_bits.u, expected_bits.u);
+        boundary_fail++;
+      }
+    }
+  }
+
+  if (boundary_fail == 0) {
+    printf("%sPASS%s: vfwmaccbf16.vf boundary cases matched expansion.\n",
+           COLOR_GREEN, COLOR_RESET);
+  } else {
+    printf("%sFAIL%s: vfwmaccbf16.vf boundary cases failed %d/%d lanes.\n",
+           COLOR_RED, COLOR_RESET, boundary_fail, num_boundary_tests * 4);
+  }
+
+  // Test 4: Deterministic random operation against expanded sequence
+  printf("\nTest 4: Deterministic random operation\n");
+  int random_fail = 0;
+  for (int iter = 0; iter < 32; iter++) {
+    uint16_t rs1 = (uint16_t)(vec_rand() >> 16);
+    uint16_t vs2[4];
+    float actual[4];
+    float expected[4];
+    int rm = iter % 5;
+
+    for (int i = 0; i < 4; i++) {
+      float_bits vd_bits;
+      vs2[i] = (uint16_t)(vec_rand() >> 16);
+      vd_bits.u = vec_rand();
+      actual[i] = vd_bits.f;
+      expected[i] = vd_bits.f;
+    }
+
+    run_vfwmaccbf16_vf(rs1, vs2, actual, rm, 4);
+    expand_vfwmaccbf16_vf(rs1, vs2, expected, rm, 4);
+
+    for (int i = 0; i < 4; i++) {
+      if (!fp32_same_or_both_nan(actual[i], expected[i])) {
+        if (random_fail < 8) {
+          float_bits actual_bits;
+          float_bits expected_bits;
+          actual_bits.f = actual[i];
+          expected_bits.f = expected[i];
+          printf("%sFAIL%s: random [%s] lane%d -> 0x%08x, expected 0x%08x\n",
+                 COLOR_RED, COLOR_RESET, vec_rounding_mode_name(rm), i,
+                 actual_bits.u, expected_bits.u);
+        }
+        random_fail++;
+      }
+    }
+  }
+
+  if (random_fail == 0) {
+    printf("%sPASS%s: vfwmaccbf16.vf random test matched 128 lanes.\n",
+           COLOR_GREEN, COLOR_RESET);
+  } else {
+    printf("%sFAIL%s: vfwmaccbf16.vf random test failed %d/128 lanes.\n",
+           COLOR_RED, COLOR_RESET, random_fail);
   }
 
   printf("\nvfwmaccbf16.vf test completed\n\n");

--- a/tests/bf16/test_vec.c
+++ b/tests/bf16/test_vec.c
@@ -1,19 +1,32 @@
 #include "bf16.h"
 
+static uint32_t vec_rand_state = 0x9E3779B9u;
+
+static uint32_t vec_rand(void) {
+  vec_rand_state = vec_rand_state * 1103515245u + 12345u;
+  return vec_rand_state;
+}
+
+static int active_lanes(int base, int total) {
+  int lanes = total - base;
+  return lanes < 4 ? lanes : 4;
+}
+
 void test_vfncvtbf16() {
   printf("Testing vfncvtbf16.f.f.w (Vector convert FP32 to BF16):\n");
 
   // Test 1: Basic conversion
   printf("\nTest 1: Basic conversion\n");
 
-  // Test with vector length 8
+  // Test with vector length 4
   float test_values[4] = {};
   uint16_t results[4] = {3, 3, 3, 3};
 
-  // int idx = 0;
-  for (int base = 0; base + 4 < num_test_cases; base += 4) {
-    for (int i = base; i < base + 4; i++) {
-      test_values[i - base] = test_cases[i].input;
+  for (int base = 0; base < num_test_cases; base += 4) {
+    int lanes = active_lanes(base, num_test_cases);
+    for (int i = 0; i < 4; i++) {
+      test_values[i] = i < lanes ? test_cases[base + i].input : 0.0f;
+      results[i] = 0xA5A5;
     }
     asm volatile("csrwi frm,0 \n"
                  "vsetivli zero, 4, e32, m1, ta, ma\n"
@@ -26,14 +39,15 @@ void test_vfncvtbf16() {
                  : "r"(test_values), "r"(results)
                  : "v0", "v1", "v2", "memory");
     // Check results
-    for (int i = base; i < base + 4; i++) {
-      uint16_t expected = test_cases[i].expected;
-      if (results[i - base] == expected) {
+    for (int i = 0; i < lanes; i++) {
+      uint16_t expected = test_cases[base + i].expected;
+      if (bf16_matches_float_conversion(test_values[i], results[i],
+                                        expected)) {
         printf("%sPASS%s: %g -> 0x%04x\n", COLOR_GREEN, COLOR_RESET,
-               test_values[i - base], results[i - base]);
+               test_values[i], results[i]);
       } else {
         printf("%sFAIL%s: %g -> 0x%04x, expected 0x%04x\n", COLOR_RED,
-               COLOR_RESET, test_values[i - base], results[i - base], expected);
+               COLOR_RESET, test_values[i], results[i], expected);
       }
     }
   }
@@ -64,7 +78,8 @@ void test_vfncvtbf16() {
   for (int i = 0; i < 4; i++) {
     if (mask[i]) {
       uint16_t expected = test_cases[i].expected;
-      if (masked_results[i] == expected) {
+      if (bf16_matches_float_conversion(masked_values[i], masked_results[i],
+                                        expected)) {
         printf("%sPASS%s: [masked] %g -> 0x%04x\n", COLOR_GREEN, COLOR_RESET,
                masked_values[i], masked_results[i]);
       } else {
@@ -82,6 +97,52 @@ void test_vfncvtbf16() {
     }
   }
 
+  // Test 3: Deterministic random operation
+  printf("\nTest 3: Deterministic random operation\n");
+
+  int random_fail = 0;
+  for (int iter = 0; iter < 64; iter++) {
+    for (int i = 0; i < 4; i++) {
+      float_bits input;
+      input.u = vec_rand();
+      test_values[i] = input.f;
+      results[i] = 0x5A5A;
+    }
+
+    asm volatile("csrwi frm,0 \n"
+                 "vsetivli zero, 4, e32, m1, ta, ma\n"
+                 "vle32.v v2, (%0)\n"
+                 "vsetivli zero, 4, e16, m1, ta, ma\n"
+                 "vfncvtbf16.f.f.w v0, v2\n"
+                 "vse16.v v0, (%1)\n"
+                 "fence rw, rw\n"
+                 :
+                 : "r"(test_values), "r"(results)
+                 : "v0", "v1", "v2", "memory");
+
+    for (int i = 0; i < 4; i++) {
+      uint16_t expected = float_to_bf16_soft(test_values[i]);
+      if (!bf16_matches_float_conversion(test_values[i], results[i],
+                                         expected)) {
+        if (random_fail < 8) {
+          float_bits bits;
+          bits.f = test_values[i];
+          printf("%sFAIL%s: random bits=0x%08x -> 0x%04x, expected 0x%04x\n",
+                 COLOR_RED, COLOR_RESET, bits.u, results[i], expected);
+        }
+        random_fail++;
+      }
+    }
+  }
+
+  if (random_fail == 0) {
+    printf("%sPASS%s: vfncvtbf16 random conversion matched 256 lanes.\n",
+           COLOR_GREEN, COLOR_RESET);
+  } else {
+    printf("%sFAIL%s: vfncvtbf16 random conversion failed %d/256 lanes.\n",
+           COLOR_RED, COLOR_RESET, random_fail);
+  }
+
   printf("\nvfncvtbf16.f.f.w test completed\n\n");
 }
 
@@ -95,9 +156,11 @@ void test_vfwcvtbf16() {
   uint16_t bf16_values[4];
   float results[4];
 
-  for (int base = 0; base + 4 < num_test_cases; base += 4) {
-    for (int i = base; i < base + 4; i++) {
-      bf16_values[i - base] = test_cases[i].expected;
+  for (int base = 0; base < num_test_cases; base += 4) {
+    int lanes = active_lanes(base, num_test_cases);
+    for (int i = 0; i < 4; i++) {
+      bf16_values[i] = i < lanes ? test_cases[base + i].expected : 0;
+      results[i] = -3.0f;
     }
     asm volatile("csrwi frm,0 \n"
                  "vsetivli zero, 4, e16, m1, ta, ma\n"
@@ -112,23 +175,19 @@ void test_vfwcvtbf16() {
                    "memory"); // v2-v3 for EMUL=2 with e32
 
     // Check results
-    for (int i = base; i < base + 4; i++) {
-      float expected = test_cases[i].input;
+    for (int i = 0; i < lanes; i++) {
       float_bits result_bits;
-      result_bits.f = results[i - base];
-      if (float_equal(results[i - base], expected, 1e-6f, 1e-5f)) {
+      result_bits.f = results[i];
+      if (float_matches_bf16_conversion(bf16_values[i], results[i])) {
         printf("%sPASS%s: 0x%04x -> %g\n", COLOR_GREEN, COLOR_RESET,
-               bf16_values[i - base], results[i - base]);
+               bf16_values[i], results[i]);
       } else {
-        float expected2 = bf16_to_float_soft(test_cases[i].expected);
-        if (float_equal(results[i - base], expected2, 1e-6f, 1e-5f)) {
-          printf("%sPASS%s: 0x%04x -> %g~%g\n", COLOR_GREEN, COLOR_RESET,
-                 bf16_values[i - base], results[i - base], expected);
-        } else {
-          printf("%sFAIL%s: 0x%04x -> %g/%08x, expected %g\n", COLOR_RED,
-                 COLOR_RESET, bf16_values[i - base], results[i - base],
-                 result_bits.u, expected2);
-        }
+        float expected2 = bf16_to_float_soft(bf16_values[i]);
+        float_bits expected_bits;
+        expected_bits.f = expected2;
+        printf("%sFAIL%s: 0x%04x -> %g/%08x, expected %g/%08x\n",
+               COLOR_RED, COLOR_RESET, bf16_values[i], results[i],
+               result_bits.u, expected2, expected_bits.u);
       }
     }
   }
@@ -160,11 +219,11 @@ void test_vfwcvtbf16() {
 
   for (int i = 0; i < 4; i++) {
     if (mask[i]) {
-      float expected = test_cases[i].input;
-      if (float_equal(masked_results[i], expected, 1e-6f, 1e-5f)) {
+      if (float_matches_bf16_conversion(masked_bf16[i], masked_results[i])) {
         printf("%sPASS%s: [masked] 0x%04x -> %g\n", COLOR_GREEN, COLOR_RESET,
                masked_bf16[i], masked_results[i]);
       } else {
+        float expected = bf16_to_float_soft(masked_bf16[i]);
         printf("%sFAIL%s: [masked] 0x%04x -> %g, expected %g\n", COLOR_RED,
                COLOR_RESET, masked_bf16[i], masked_results[i], expected);
       }
@@ -177,6 +236,51 @@ void test_vfwcvtbf16() {
                COLOR_RESET, masked_bf16[i], masked_results[i]);
       }
     }
+  }
+
+  // Test 3: Deterministic random operation
+  printf("\nTest 3: Deterministic random operation\n");
+
+  int random_fail = 0;
+  for (int iter = 0; iter < 64; iter++) {
+    for (int i = 0; i < 4; i++) {
+      bf16_values[i] = (uint16_t)(vec_rand() >> 16);
+      results[i] = -3.0f;
+    }
+
+    asm volatile("csrwi frm,0 \n"
+                 "vsetivli zero, 4, e16, m1, ta, ma\n"
+                 "vle16.v v2, (%0)\n"
+                 "vfwcvtbf16.f.f.v v0, v2\n"
+                 "vsetivli zero, 4, e32, m1, ta, ma\n"
+                 "vse32.v v0, (%1)\n"
+                 "fence rw, rw\n"
+                 :
+                 : "r"(bf16_values), "r"(results)
+                 : "v0", "v1", "v2", "v3", "memory");
+
+    for (int i = 0; i < 4; i++) {
+      if (!float_matches_bf16_conversion(bf16_values[i], results[i])) {
+        if (random_fail < 8) {
+          float_bits actual_bits;
+          float_bits expected_bits;
+          actual_bits.f = results[i];
+          expected_bits.f = bf16_to_float_soft(bf16_values[i]);
+          printf("%sFAIL%s: random 0x%04x -> 0x%08x, expected 0x%08x\n",
+                 COLOR_RED, COLOR_RESET, bf16_values[i], actual_bits.u,
+                 expected_bits.u);
+        }
+        random_fail++;
+      }
+    }
+  }
+
+  if (random_fail == 0) {
+    printf("%sPASS%s: vfwcvtbf16 random conversion matched 256 lanes.\n",
+           COLOR_GREEN, COLOR_RESET);
+  } else {
+    printf("%sFAIL%s: vfwcvtbf16 random conversion failed %d/256 lanes.\n",
+           COLOR_RED, COLOR_RESET, random_fail);
   }
 
   printf("vfwcvtbf16.f.f.v test completed\n\n");


### PR DESCRIPTION
## Changes on This Commit
1. Fix condition overleap on [BF16 test case](https://github.com/OpenXiangShan/nexus-am/compare/master...physics1024:nexus-am:master?expand=1#diff-076b77fb1cdf4bd6138b118c22ee930b36b34d3dafb298fbe3ac05aecec06002).
2. Add other round conditions in frm CSR, subnormal contions, random data and oracle assertion tests into BF16 test case, make it more exhaustive.
3. Add a [fast mode for BF16 test case](https://github.com/OpenXiangShan/nexus-am/compare/master...physics1024:nexus-am:master?expand=1#diff-c2315143212093bb77ae5606a37d779b832a1da6de66808ba0e3bded1fcd6565), removing memory tests in original test case to make simulation faster.