### PR TITLE
feat(icache-ecc-test): support kunminghu-v3 hardware error

### DIFF
--- a/apps/icache-ecc-test/Makefile
+++ b/apps/icache-ecc-test/Makefile
@@ -1,3 +1,3 @@
 NAME = icache-ecc-test
-SRCS = main.c
+SRCS = main.c trap.S
 include $(AM_HOME)/Makefile.app

--- a/apps/icache-ecc-test/main.c
+++ b/apps/icache-ecc-test/main.c
@@ -1,6 +1,10 @@
 #include <klib.h>
 #include "./eccctrl.h"
 
+#define MSTATUS_MIE (1ul << 3)
+#define MCAUSE_ILLEGAL_INSTRUCTION 0x2
+#define MCAUSE_HARDWARE_ERROR 0x13
+
 #define TEST_LOG_LEVEL_ERROR 2
 #define TEST_LOG_LEVEL_INFO 1
 #define TEST_LOG_LEVEL_DEBUG 0
@@ -25,6 +29,36 @@
 #endif
 
 #define MAX_WAIT 100
+
+extern void icache_ecc_trap_entry(void);
+
+uintptr_t exception_handler(uint64_t mcause, uint64_t mtval, uint64_t mstatus, uintptr_t mepc) {
+    INFO("Exception caught @ 0x%lx: mcause=0x%lx, mtval=0x%lx, mstatus=0x%lx\n",
+           mepc, mcause, mtval, mstatus);
+
+    switch (mcause) {
+    case MCAUSE_HARDWARE_ERROR:
+        INFO("  is hardware error, do fence.i and return to mepc\n");
+        asm volatile("fence.i" ::: "memory");
+        return mepc;
+    case MCAUSE_ILLEGAL_INSTRUCTION:
+        ERROR("  is illegal instruction, can be a frontend bug or backend exception selection problem, fence.i and return to mepc anyway\n");
+        uint64_t mcycle = 0;
+        asm volatile("csrr %0, mcycle" : "=r"(mcycle));
+        ERROR("  HINT: mcycle=%lu, better dump and check the waveform\n", mcycle);
+        asm volatile("fence.i" ::: "memory");
+        return mepc;
+    default:
+        ERROR("  unexpected mcause, halt now\n");
+        _halt(1);
+    }
+}
+
+static inline void setup_mmode_exception(void) {
+    uintptr_t handler = (uintptr_t)icache_ecc_trap_entry;
+    asm volatile("csrw mtvec, %0" : : "r"(handler) : "memory");
+    asm volatile("csrc mstatus, %0" : : "r"(MSTATUS_MIE) : "memory");
+}
 
 int __attribute__((noinline)) target() {
     static int n = 0;
@@ -94,6 +128,8 @@ fail:
 
 int main() {
     int failed = 0;
+
+    setup_mmode_exception();
 
     failed += test(ITARGET_SET(ITARGET_META) | INJECT | ENABLE, target, ISTATUS_INJECTED, 0, "Inject metaArray");
     failed += test(ITARGET_SET(ITARGET_DATA) | INJECT | ENABLE, target, ISTATUS_INJECTED, 0, "Inject dataArray");

--- a/apps/icache-ecc-test/trap.S
+++ b/apps/icache-ecc-test/trap.S
@@ -1,0 +1,43 @@
+#if __riscv_xlen == 64
+# define STORE    sd
+# define LOAD     ld
+# define REGBYTES 8
+#else
+# define STORE    sw
+# define LOAD     lw
+# define REGBYTES 4
+#endif
+
+#define CONTEXT_SIZE (5 * REGBYTES)
+#define OFF_RA       (0 * REGBYTES)
+#define OFF_T0       (1 * REGBYTES)
+#define OFF_T1       (2 * REGBYTES)
+#define OFF_T2       (3 * REGBYTES)
+#define OFF_T3       (4 * REGBYTES)
+
+  .section .text
+  .align 2
+  .globl icache_ecc_trap_entry
+icache_ecc_trap_entry:
+  addi sp, sp, -CONTEXT_SIZE
+  STORE ra, OFF_RA(sp)
+  STORE t0, OFF_T0(sp)
+  STORE t1, OFF_T1(sp)
+  STORE t2, OFF_T2(sp)
+  STORE t3, OFF_T3(sp)
+
+  csrr a0, mcause
+  csrr a1, mtval
+  csrr a2, mstatus
+  csrr a3, mepc
+  call exception_handler
+
+  csrw mepc, a0
+
+  LOAD ra, OFF_RA(sp)
+  LOAD t0, OFF_T0(sp)
+  LOAD t1, OFF_T1(sp)
+  LOAD t2, OFF_T2(sp)
+  LOAD t3, OFF_T3(sp)
+  addi sp, sp, CONTEXT_SIZE
+  mret


### PR DESCRIPTION
Output example:
```
=== [0] Inject metaArray ===
Call target() first to make sure it is in the icache
Hello, World @ 0!
ECC inject start! eccctrl=0x3
ECC inject done! eccctrl=0x21
No error, call target()
Exception caught @ 0x8000012a: mcause=0x13, mtval=0x0, mstatus=0x8000040a00007800
  is hardware error, do fence.i and return to mepc
Hello, World @ 1!
=== [0] Test passed! ===

=== [1] Inject dataArray ===
Call target() first to make sure it is in the icache
Hello, World @ 2!
ECC inject start! eccctrl=0xb
ECC inject done! eccctrl=0x29
No error, call target()
Exception caught @ 0x8000012a: mcause=0x2, mtval=0x0, mstatus=0x8000040a00007800
  is illegal instruction, can be a frontend bug or backend exception selection problem, fence.i and return to mepc anyway
  HINT: mcycle=105123, better dump and check the waveform
Hello, World @ 3!
=== [1] Test passed! ===

=== [2] Inject to invalid target ===
ECC inject start! eccctrl=0x7
ECC inject done! eccctrl=0xf5
=== [2] Test passed! ===

=== [3] Inject when ecc not enabled ===
ECC inject start! eccctrl=0x2
ECC inject done! eccctrl=0x70
=== [3] Test passed! ===

=== [4] Inject to invalid address ===
ECC inject start! eccctrl=0x3
ECC inject done! eccctrl=0x171
=== [4] Test passed! ===

=== [5] IStatus & IError read-only ===
ECC inject start! eccctrl=0x91
ECC inject done! eccctrl=0x1
=== [5] Test passed! ===

Core 0: HIT GOOD TRAP at pc = 0x80000420
Core-0 instrCnt = 42,769, cycleCnt = 188,552, IPC = 0.226829
```

Currently we seems to have a backend exception selection bug (decode EX_II has higher priority than icache EX_HWE), so it reports illegal instruction in Test[1]. After fix should be hardware error.