### PR TITLE
chore: use dependabot to track actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
[Node.js 20 is being deprecated](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), so we need to update the version of the actions used in our CI. However, manually updating them all the time is a hassle.

This PR uses GitHub Dependabot to provide a more automated way to handle updates.

Showcase in xs-env: https://github.com/OpenXiangShan/xs-env/pull/87

After this PR is merged, a maintainer with owner permissions needs to enable it on the [Insights -> Dependency graph -> Dependabot](https://github.com/OpenXiangShan/nexus-am/network/updates) page